### PR TITLE
add redirect on missing path

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import IconButton from '@mui/material/IconButton'
 import Close from '@mui/icons-material/Close'
 import { SnackbarProvider, SnackbarKey, useSnackbar } from 'notistack'
-import { BrowserRouter, Route, Routes } from 'react-router-dom'
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
 import Layout from 'components/Layout'
 import Dashboard from 'pages/Dashboard'
 import Account from 'pages/Account'
@@ -26,6 +26,7 @@ const App: React.FC = () => {
           {IS_STANDALONE ? (
             <Routes>
               <Route path="/" element={<Workspace />} />
+              <Route path="*" element={<Navigate replace to="/" />} />
             </Routes>
           ) : (
             <Routes>
@@ -38,6 +39,7 @@ const App: React.FC = () => {
                 <Route path="" element={<Workspaces />} />
                 <Route path=":workspaceId" element={<Workspace />} />
               </Route>
+              <Route path="*" element={<Navigate replace to="/" />} />
             </Routes>
           )}
         </Layout>


### PR DESCRIPTION
frontendで規定外のパスを受け取った際にはルートへリダイレクトする処理を追加
以下のPRコメントに関連

https://github.com/arayabrain/optinist-for-server/pull/50/files/d923d50d99bcb3dbf962af42f5892ede792de125#r1260561360

- なお、backendのAPIサーバでは不適切なパスには404が返されるのが妥当と思われるため、上記PRの該当コードは削除する予定
    ```
    @app.get("/{_:path}")
    async def index(request: Request):
        return await root(request)
    ```
- 本PRはbarebone、optinistにもmerge予定
