### PR TITLE
improve auth actions on layout

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import Workspace from 'pages/Workspace/Workspace'
 import { IS_STANDALONE } from 'const/Mode'
 import Layout from "components/Layout";
 import Database from 'pages/Database'
+import PublicDatabase from 'pages/PublicDatabase'
 
 const App: React.FC = () => {
   return (
@@ -37,7 +38,7 @@ const App: React.FC = () => {
               <Route path="/login" element={<Login />} />
               <Route path="/reset-password" element={<ResetPassword />} />
               <Route path="/database" element={<Database />} />
-              <Route path="/database-public" element={<Database />} />
+              <Route path="/database-public" element={<PublicDatabase />} />
               <Route path="/workspaces">
                 <Route path="" element={<Workspaces />} />
                 <Route path=":workspaceId" element={<Workspace />} />

--- a/frontend/src/components/PublicLayout/PublicFooter.tsx
+++ b/frontend/src/components/PublicLayout/PublicFooter.tsx
@@ -1,0 +1,25 @@
+import { FC } from 'react'
+import { Box, Container, Divider, Grid, Typography } from '@mui/material'
+
+const PublicFooter: FC = () => {
+  return (
+    <>
+      <Box sx={{ paddingTop: 4, paddingBottom: 2 }}>
+        <Divider />
+      </Box>
+      <Box>
+        <Container>
+          <Grid container direction="column" alignItems="center">
+            <Grid item xs={12}>
+              <Typography>
+                {`${new Date().getFullYear()}`} Studio. All rights reserved.
+              </Typography>
+            </Grid>
+          </Grid>
+        </Container>
+      </Box>
+    </>
+  )
+}
+
+export default PublicFooter

--- a/frontend/src/components/PublicLayout/PublicHeader.tsx
+++ b/frontend/src/components/PublicLayout/PublicHeader.tsx
@@ -1,0 +1,37 @@
+import { FC } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { AppBar, Button, Container, Toolbar, Typography } from '@mui/material'
+
+const PublicHeader: FC = () => {
+  return (
+    <AppBar position="fixed">
+      <Container>
+        <Toolbar>
+          <Typography sx={{ fontWeight: 600, fontSize: 22, mr: 2 }}>
+            PUB STUDIO
+          </Typography>
+          <PublicNavMenu displayName="Home" navLink="/" />
+          <PublicNavMenu displayName="Database" navLink="/database-public" />
+        </Toolbar>
+      </Container>
+    </AppBar>
+  )
+}
+
+const PublicNavMenu: FC<{
+  displayName: string
+  navLink: string
+}> = ({ displayName, navLink }) => {
+  const navigate = useNavigate()
+  const handleMenuClick = () => {
+    navigate(navLink)
+  }
+
+  return (
+    <Button key={displayName} onClick={handleMenuClick}>
+      <Typography color="white">{displayName}</Typography>
+    </Button>
+  )
+}
+
+export default PublicHeader

--- a/frontend/src/components/PublicLayout/index.tsx
+++ b/frontend/src/components/PublicLayout/index.tsx
@@ -1,0 +1,16 @@
+import { FC } from 'react'
+import { Box } from '@mui/material'
+import PublicHeader from 'components/PublicLayout/PublicHeader'
+import PublicFooter from 'components/PublicLayout/PublicFooter'
+
+const PublicLayout: FC = ({ children }) => {
+  return (
+    <Box sx={{ height: '100%', width: '100%' }}>
+      <PublicHeader />
+      <Box>{children}</Box>
+      <PublicFooter />
+    </Box>
+  )
+}
+
+export default PublicLayout

--- a/frontend/src/pages/PublicDatabase/index.tsx
+++ b/frontend/src/pages/PublicDatabase/index.tsx
@@ -1,0 +1,12 @@
+import PublicLayout from "components/PublicLayout"
+import Database from "pages/Database"
+
+const PublicDatabase = () => {
+  return(
+    <PublicLayout>
+      <Database />
+    </PublicLayout>
+  )
+}
+
+export default PublicDatabase


### PR DESCRIPTION
- `ignorePaths`, `loginPaths`, `isPageLogin`は変数の意図が伝わりにくかったためrename
- useEffectで`authIgnorePaths`の場合にauthCheckが除外されていなかった問題を修正
- `/database-public`を`authIgnorePaths`に追加
