### PR TITLE
Feature/switch workflow

### DIFF
--- a/frontend/src/api/experiments/Experiments.ts
+++ b/frontend/src/api/experiments/Experiments.ts
@@ -102,6 +102,15 @@ export async function downloadExperimentConfigApi(
   return response.data
 }
 
+export async function fetchExperimentApi(
+  workspace_id: string,
+): Promise<ExperimentDTO> {
+  const response = await axios.get(
+    `${BASE_URL}/experiments/fetch/${workspace_id}`,
+  )
+  return response.data
+}
+
 export async function renameExperiment(
   workspaceId: string,
   uid: string,

--- a/frontend/src/pages/Workspace/Workspace.tsx
+++ b/frontend/src/pages/Workspace/Workspace.tsx
@@ -13,6 +13,7 @@ import {
   setCurrentWorkspace,
 } from 'store/slice/Workspace/WorkspaceSlice'
 import { selectActiveTab } from 'store/slice/Workspace/WorkspaceSelector'
+import { fetchExperiment } from 'store/slice/Experiments/ExperimentsActions'
 
 const Workspace: React.FC = () => {
   const dispatch = useDispatch()
@@ -23,8 +24,9 @@ const Workspace: React.FC = () => {
   useEffect(() => {
     if (IS_STANDALONE) {
       dispatch(setCurrentWorkspace(STANDALONE_WORKSPACE_ID))
-    } else {
-      workspaceId && dispatch(setCurrentWorkspace(workspaceId))
+    } else if (workspaceId) {
+      dispatch(setCurrentWorkspace(workspaceId))
+      dispatch(fetchExperiment(workspaceId))
     }
     return () => {
       dispatch(clearCurrentWorkspace())

--- a/frontend/src/store/slice/AlgorithmNode/AlgorithmNodeSlice.ts
+++ b/frontend/src/store/slice/AlgorithmNode/AlgorithmNodeSlice.ts
@@ -6,7 +6,10 @@ import {
   deleteFlowNodeById,
 } from '../FlowElement/FlowElementSlice'
 import { NODE_TYPE_SET } from '../FlowElement/FlowElementType'
-import { importExperimentByUid } from '../Experiments/ExperimentsActions'
+import {
+  fetchExperiment,
+  importExperimentByUid,
+} from '../Experiments/ExperimentsActions'
 import { getAlgoParams } from './AlgorithmNodeActions'
 import { ALGORITHM_NODE_SLICE_NAME, AlgorithmNode } from './AlgorithmNodeType'
 import { isAlgorithmNodePostData } from 'api/run/RunUtils'
@@ -68,22 +71,25 @@ export const algorithmNodeSlice = createSlice({
           delete state[action.payload]
         }
       })
-      .addCase(importExperimentByUid.fulfilled, (_, action) => {
-        const newState: AlgorithmNode = {}
-        Object.values(action.payload.nodeDict)
-          .filter(isAlgorithmNodePostData)
-          .forEach((node) => {
-            if (node.data != null) {
-              newState[node.id] = {
-                name: node.data.label,
-                functionPath: node.data.path,
-                params: node.data.param,
-                isUpdated: false,
+      .addMatcher(
+        isAnyOf(importExperimentByUid.fulfilled, fetchExperiment.fulfilled),
+        (_, action) => {
+          const newState: AlgorithmNode = {}
+          Object.values(action.payload.nodeDict)
+            .filter(isAlgorithmNodePostData)
+            .forEach((node) => {
+              if (node.data != null) {
+                newState[node.id] = {
+                  name: node.data.label,
+                  functionPath: node.data.path,
+                  params: node.data.param,
+                  isUpdated: false,
+                }
               }
-            }
-          })
-        return newState
-      })
+            })
+          return newState
+        },
+      )
       .addMatcher(
         isAnyOf(run.fulfilled, runByCurrentUid.fulfilled),
         (state, action) => {

--- a/frontend/src/store/slice/Experiments/ExperimentsActions.ts
+++ b/frontend/src/store/slice/Experiments/ExperimentsActions.ts
@@ -1,10 +1,12 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
 import {
+  ExperimentDTO,
   ExperimentsDTO,
   getExperimentsApi,
   deleteExperimentByUidApi,
   importExperimentByUidApi,
   deleteExperimentByListApi,
+  fetchExperimentApi,
 } from 'api/experiments/Experiments'
 import { RunPostData } from 'api/run/Run'
 import { EXPERIMENTS_SLICE_NAME } from './ExperimentsType'
@@ -73,6 +75,18 @@ export const importExperimentByUid = createAsyncThunk<
   async ({ workspaceId, uid }, thunkAPI) => {
     try {
       const response = await importExperimentByUidApi(workspaceId, uid)
+      return response
+    } catch (e) {
+      return thunkAPI.rejectWithValue(e)
+    }
+  },
+)
+
+export const fetchExperiment = createAsyncThunk<ExperimentDTO, string>(
+  `${EXPERIMENTS_SLICE_NAME}/fetchExperiment`,
+  async (workspaceId, thunkAPI) => {
+    try {
+      const response = await fetchExperimentApi(workspaceId)
       return response
     } catch (e) {
       return thunkAPI.rejectWithValue(e)

--- a/frontend/src/store/slice/Experiments/ExperimentsSlice.ts
+++ b/frontend/src/store/slice/Experiments/ExperimentsSlice.ts
@@ -4,8 +4,12 @@ import {
   getExperiments,
   deleteExperimentByUid,
   deleteExperimentByList,
+  fetchExperiment,
 } from './ExperimentsActions'
-import { convertToExperimentListType } from './ExperimentsUtils'
+import {
+  convertToExperimentListType,
+  convertToExperimentType,
+} from './ExperimentsUtils'
 import {
   pollRunResult,
   run,
@@ -61,6 +65,12 @@ export const experimentsSlice = createSlice({
               target.functions[nodeId].status = 'error'
             }
           })
+        }
+      })
+      .addCase(fetchExperiment.fulfilled, (state, action) => {
+        if (state.status === 'fulfilled') {
+          state.experimentList[action.payload.unique_id] =
+            convertToExperimentType(action.payload)
         }
       })
       .addMatcher(isAnyOf(run.fulfilled, runByCurrentUid.fulfilled), () => {

--- a/frontend/src/store/slice/Experiments/ExperimentsUtils.ts
+++ b/frontend/src/store/slice/Experiments/ExperimentsUtils.ts
@@ -1,4 +1,9 @@
-import type { ExperimentDTO, ExperimentsDTO } from 'api/experiments/Experiments'
+import type {
+  ExperimentDTO,
+  ExperimentsDTO,
+  FunctionsDTO,
+} from 'api/experiments/Experiments'
+import { RunResultDTO } from 'api/run/Run'
 import type {
   ExperimentListType,
   ExperimentType,
@@ -47,6 +52,21 @@ function convertToExperimentStatus(dto: string): EXPERIMENTS_STATUS {
     default:
       throw new Error('failed to convert to EXPERIMENTS_STATUS')
   }
+}
+
+export function convertFunctionsToRunResultDTO(
+  dto: FunctionsDTO,
+): RunResultDTO {
+  const result: RunResultDTO = {}
+  Object.entries(dto).forEach(([nodeId, value]) => {
+    result[nodeId] = {
+      status: value.success,
+      message: value.message ?? '',
+      name: value.name,
+      outputPaths: value.outputPaths,
+    }
+  })
+  return result
 }
 
 export function convertToFlowChartList(

--- a/frontend/src/store/slice/FlowElement/FlowElementSlice.ts
+++ b/frontend/src/store/slice/FlowElement/FlowElementSlice.ts
@@ -103,6 +103,18 @@ export const flowElementSlice = createSlice({
           [{ id: element.id, type: 'remove' }],
           state.flowNodes,
         )
+        state.flowEdges = applyEdgeChanges(
+          state.flowEdges
+            .filter((edge) => {
+              return (
+                edge.source === action.payload || edge.target === action.payload
+              )
+            })
+            .map((edge) => {
+              return { id: edge.id, type: 'remove' }
+            }),
+          state.flowEdges,
+        )
       }
     },
     editFlowNodePositionById: (

--- a/frontend/src/store/slice/Pipeline/PipelineSlice.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineSlice.ts
@@ -1,5 +1,8 @@
 import { createSlice, isAnyOf, PayloadAction } from '@reduxjs/toolkit'
-import { importExperimentByUid } from '../Experiments/ExperimentsActions'
+import {
+  fetchExperiment,
+  importExperimentByUid,
+} from '../Experiments/ExperimentsActions'
 import { pollRunResult, run, runByCurrentUid } from './PipelineActions'
 import {
   Pipeline,
@@ -14,6 +17,7 @@ import {
   convertToRunResult,
   isNodeResultPending,
 } from './PipelineUtils'
+import { convertFunctionsToRunResultDTO } from '../Experiments/ExperimentsUtils'
 
 const initialState: Pipeline = {
   run: {
@@ -66,6 +70,37 @@ export const pipelineSlice = createSlice({
         state.runBtn = RUN_BTN_OPTIONS.RUN_ALREADY
         state.run = {
           status: RUN_STATUS.START_UNINITIALIZED,
+        }
+      })
+      .addCase(fetchExperiment.rejected, () => initialState)
+      .addCase(fetchExperiment.fulfilled, (state, action) => {
+        state.currentPipeline = {
+          uid: action.payload.unique_id,
+        }
+        state.runBtn = RUN_BTN_OPTIONS.RUN_ALREADY
+        state.run = {
+          uid: action.payload.unique_id,
+          status: RUN_STATUS.START_SUCCESS,
+          runResult: {
+            ...convertToRunResult(
+              convertFunctionsToRunResultDTO(action.payload.function),
+            ),
+          },
+          runPostData: {
+            name: action.payload.name,
+            nodeDict: action.payload.nodeDict,
+            edgeDict: action.payload.edgeDict,
+            snakemakeParam: {},
+            nwbParam: {},
+            forceRunList: [],
+          },
+        }
+
+        const runResultPendingList = Object.values(state.run.runResult).filter(
+          isNodeResultPending,
+        )
+        if (runResultPendingList.length === 0) {
+          state.run.status = RUN_STATUS.FINISHED
         }
       })
       .addMatcher(

--- a/frontend/src/store/slice/Pipeline/PipelineUtils.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineUtils.ts
@@ -67,6 +67,11 @@ export function convertToRunResult(dto: RunResultDTO) {
         name: nodeResultDto.name,
         outputPaths: convertToOutputPath(outputPath),
       }
+    } else if (nodeResultDto.status === 'running') {
+      result[nodeId] = {
+        status: NODE_RESULT_STATUS.PENDING,
+        name: nodeResultDto.name,
+      }
     } else {
       result[nodeId] = {
         status: NODE_RESULT_STATUS.ERROR,

--- a/frontend/src/store/slice/RightDrawer/RightDrawerSlice.ts
+++ b/frontend/src/store/slice/RightDrawer/RightDrawerSlice.ts
@@ -1,5 +1,8 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit'
-import { importExperimentByUid } from '../Experiments/ExperimentsActions'
+import { createSlice, isAnyOf, PayloadAction } from '@reduxjs/toolkit'
+import {
+  fetchExperiment,
+  importExperimentByUid,
+} from '../Experiments/ExperimentsActions'
 import {
   deleteFlowNodes,
   deleteFlowNodeById,
@@ -19,7 +22,7 @@ export const RIGHT_DRAWER_MODE = {
 } as const
 
 export type RIGHT_DRAWER_MODE_TYPE =
-  (typeof RIGHT_DRAWER_MODE)[keyof typeof RIGHT_DRAWER_MODE]
+  typeof RIGHT_DRAWER_MODE[keyof typeof RIGHT_DRAWER_MODE]
 
 const initialState: RightDrawer = {
   open: false,
@@ -91,6 +94,10 @@ export const rightDrawerSlice = createSlice({
       .addCase(importExperimentByUid.fulfilled, () => {
         return initialState
       })
+      .addMatcher(
+        isAnyOf(fetchExperiment.fulfilled, fetchExperiment.rejected),
+        () => initialState,
+      )
   },
 })
 

--- a/studio/app/common/core/experiment/experiment_utils.py
+++ b/studio/app/common/core/experiment/experiment_utils.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+from glob import glob
+from typing import Optional
+
+from studio.app.common.core.experiment.experiment import ExptConfig
+from studio.app.common.core.experiment.experiment_reader import ExptConfigReader
+from studio.app.common.core.utils.filepath_creater import join_filepath
+from studio.app.const import DATE_FORMAT
+from studio.app.dir_path import DIRPATH
+
+
+class ExptUtils:
+    @classmethod
+    def get_last_experiment(cls, workspace_id: str):
+        last_expt_config: Optional[ExptConfig] = None
+        config_paths = glob(
+            join_filepath(
+                [DIRPATH.OUTPUT_DIR, workspace_id, "*", DIRPATH.EXPERIMENT_YML]
+            )
+        )
+
+        for path in config_paths:
+            config = ExptConfigReader.read(path)
+            if not last_expt_config:
+                last_expt_config = config
+            elif datetime.strptime(config.started_at, DATE_FORMAT) > datetime.strptime(
+                last_expt_config.started_at, DATE_FORMAT
+            ):
+                last_expt_config = config
+        return last_expt_config

--- a/studio/app/common/routers/experiment.py
+++ b/studio/app/common/routers/experiment.py
@@ -2,11 +2,12 @@ import shutil
 from glob import glob
 from typing import Dict
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from fastapi.responses import FileResponse
 
 from studio.app.common.core.experiment.experiment import ExptConfig, ExptImportData
 from studio.app.common.core.experiment.experiment_reader import ExptConfigReader
+from studio.app.common.core.experiment.experiment_utils import ExptUtils
 from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.common.schemas.experiment import DeleteItem, RenameItem
 from studio.app.dir_path import DIRPATH
@@ -78,6 +79,16 @@ async def delete_experiment_list(workspace_id: str, deleteItem: DeleteItem):
         return True
     except Exception:
         return False
+
+
+@router.get("/fetch/{workspace_id}", response_model=ExptConfig)
+async def fetch_last_experiment(workspace_id: str):
+    print(workspace_id)
+    last_expt_config = ExptUtils.get_last_experiment(workspace_id)
+    if last_expt_config:
+        return last_expt_config
+    else:
+        raise HTTPException(status_code=404)
 
 
 @router.get("/download/config/{workspace_id}/{unique_id}")


### PR DESCRIPTION
workspaceの切り替えに対応
※本PRはbareboneにもmerge予定

### backend
- fetch apiの追加
  - 指定したworkspaceで最後に実行されたworkflowのexperiment.yamlの情報を返す

### frontend
- fetch apiから取得した内容をworkflow画面に反映
- #62 で、nodeを削除した際に結合しているedgeがstateから削除されていなかったバグを修正


現状workspaceはdefault固定になっているため、動作検証の際には
`frontend/src/store/slice/Workspace/WorkspaceSlice.ts`のinitialState.workspacesに`{workspace_id: 'dummy'}`などを追加して試してください。
