### PR TITLE
Fix actual number of items and the total of pagination not match

### DIFF
--- a/studio/app/optinist/routers/expdb.py
+++ b/studio/app/optinist/routers/expdb.py
@@ -47,6 +47,7 @@ async def search_public_experiments(
         session=db,
         query=select(optinist_model.Experiment)
         .filter_by(publish_status=PublishStatus.on)
+        .group_by(optinist_model.Experiment.id)
         .order_by(
             sort_column.desc()
             if sortOptions.sort[1] == SortDirection.desc
@@ -84,7 +85,7 @@ async def search_public_cells(
         .filter(optinist_model.Experiment.publish_status == PublishStatus.on)
     )
     query = query.filter(optinist_model.Experiment.id == exp_id) if exp_id else query
-    query = query.order_by(
+    query = query.group_by(optinist_model.Cell.id).order_by(
         sort_column.desc()
         if sortOptions.sort[1] == SortDirection.desc
         else sort_column.asc()
@@ -141,7 +142,7 @@ async def search_db_experiments(
                 ),
             )
         )
-    query = query.order_by(
+    query = query.group_by(optinist_model.Experiment.id).order_by(
         sort_column.desc()
         if sortOptions.sort[1] == SortDirection.desc
         else sort_column.asc()
@@ -211,7 +212,7 @@ async def search_db_cells(
         if exp_id
         else query
     )
-    query = query.order_by(
+    query = query.group_by(optinist_model.Cell.id).order_by(
         sort_column.desc()
         if sortOptions.sort[1] == SortDirection.desc
         else sort_column.asc()


### PR DESCRIPTION
If the query result returns duplicate objects, the fastapi-pagination response model seems to automatically ignore them, which leads to a mismatch. The solution is to add GROUP BY into the query to group objects by ID.