### PR TITLE
URL調整

### DIFF
--- a/frontend/src/components/Layout/index.tsx
+++ b/frontend/src/components/Layout/index.tsx
@@ -12,7 +12,6 @@ import { IS_STANDALONE } from 'const/Mode'
 import Loading from 'components/common/Loading'
 
 const authRequiredPathRegex = /^\/console\/?.*/
-const redirectAfterLoginPaths = ['/login', '/reset-password', '/console']
 
 const Layout = ({ children }: { children?: ReactNode }) => {
   const user = useSelector(selectCurrentUser)
@@ -20,11 +19,11 @@ const Layout = ({ children }: { children?: ReactNode }) => {
   const navigate = useNavigate()
   const dispatch = useDispatch()
 
-  const [loading, setLoadingAuth] = useState(!IS_STANDALONE && authRequiredPathRegex.test(window.location.pathname))
+  const [loading, setLoadingAuth] = useState(!IS_STANDALONE && authRequiredPathRegex.test(location.pathname))
 
   useEffect(() => {
     !IS_STANDALONE &&
-      authRequiredPathRegex.test(window.location.pathname) &&
+      authRequiredPathRegex.test(location.pathname) &&
       checkAuth()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.pathname, user])
@@ -35,18 +34,17 @@ const Layout = ({ children }: { children?: ReactNode }) => {
       return
     }
     const token = getToken()
-    const willRedirect = redirectAfterLoginPaths.includes(
-        window.location.pathname,
-    )
+    const isLogin = location.pathname === '/login'
+
 
     try {
       if (token) {
         await dispatch(getMe())
-        if (willRedirect) navigate('/console')
+        if (isLogin) navigate('/console')
         return
-      } else if (!willRedirect) throw new Error('fail auth')
+      } else if (!isLogin) throw new Error('fail auth')
     } catch {
-      navigate('/login')
+      navigate('/login', { replace: true })
     } finally {
       if(loading) setLoadingAuth(false)
     }

--- a/frontend/src/pages/Login/index.tsx
+++ b/frontend/src/pages/Login/index.tsx
@@ -1,6 +1,6 @@
 import { Box, Stack, styled, Typography } from '@mui/material'
 import { useDispatch } from 'react-redux'
-import { getMe, login } from 'store/slice/User/UserActions'
+import { login } from 'store/slice/User/UserActions'
 import { AppDispatch } from 'store/store'
 import { ChangeEvent, FormEvent, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
@@ -28,11 +28,7 @@ const Login = () => {
     dispatch(login(values))
       .unwrap()
       .then((_) => {
-        dispatch(getMe())
-          .unwrap()
-          .then((_) => {
-            navigate('/console')
-          })
+        navigate('/console')
       })
       .catch((_) => {
         setErrors({ email: 'Email or password is wrong', password: '' })

--- a/frontend/src/pages/ResetPassword/index.tsx
+++ b/frontend/src/pages/ResetPassword/index.tsx
@@ -25,6 +25,7 @@ const ResetPassword = () => {
             await sendResetPasswordMailApi(values.email)
             setTimeout(()=>{
                 alert(` You'll receive a link to reset your password at ${values.email}. Please check your mail!`)
+                navigate('/login')
             },300)
         }
         catch {


### PR DESCRIPTION
- Resolve #65 

以下の仕様を修正

- redirectAfterLoginPathsを削除
  - 認証チェック後にリダイレクトが必要になるのは現状/loginのみのため
  - パスのリストを設けておくことで開発者に誤解を招き得るため
- locationをreact-router-hooksに統一
  - window.loacation -> useLocation()
- 未認証でログインページへリダイレクトされる際に、replaceを使用
  - ブラウザバックでリダイレクト前のページに遷移可能にするため
- loginページonSubmitでのgetMe呼び出しを削除
  - Layout/index.tsxでgetMeが実行されており、冗長な処理のため
- パスワードリセットメール送信成功→アラートのOK選択後にloginページへの自動リダイレクトを追加