### PR TITLE
Update workflow navigation

### DIFF
--- a/frontend/src/api/Workspace/index.ts
+++ b/frontend/src/api/Workspace/index.ts
@@ -1,11 +1,21 @@
 import axios from 'utils/axios'
 import qs from 'qs'
-import { ItemsWorkspace, WorkspaceDataDTO } from 'store/slice/Workspace/WorkspaceType'
-import { ListShareDTO } from 'store/slice/Database/DatabaseType';
+import {
+  ItemsWorkspace,
+  WorkspaceDataDTO,
+} from 'store/slice/Workspace/WorkspaceType'
+import { ListShareDTO } from 'store/slice/Database/DatabaseType'
 
 export type WorkspacePostDataDTO = { name: string; id?: number }
 
-export const getWorkspacesApi = async (params: { [key: string]: number }): Promise<WorkspaceDataDTO> => {
+export const getWorkspaceApi = async (id: number): Promise<ItemsWorkspace> => {
+  const response = await axios.get(`/workspace/${id}`)
+  return response.data
+}
+
+export const getWorkspacesApi = async (params: {
+  [key: string]: number
+}): Promise<WorkspaceDataDTO> => {
   const paramsNew = qs.stringify(params, { indices: false })
   const response = await axios.get(`/workspaces?${paramsNew}`)
   return response.data
@@ -42,12 +52,17 @@ export const exportWorkspaceApi = async (id: number): Promise<void> => {
   return response.data
 }
 
-export const getListUserShareWorkspaceApi = async (id: number): Promise<ListShareDTO> => {
+export const getListUserShareWorkspaceApi = async (
+  id: number,
+): Promise<ListShareDTO> => {
   const response = await axios.get(`/workspace/share/${id}/status`)
   return response.data
 }
 
-export const postListUserShareWorkspaceApi = async (id: number, data: {user_ids: number[]}): Promise<boolean> => {
+export const postListUserShareWorkspaceApi = async (
+  id: number,
+  data: { user_ids: number[] },
+): Promise<boolean> => {
   const response = await axios.post(`/workspace/share/${id}/status`, data)
   return response.data
 }

--- a/frontend/src/api/experiments/Experiments.ts
+++ b/frontend/src/api/experiments/Experiments.ts
@@ -102,6 +102,15 @@ export async function downloadExperimentConfigApi(
   return response.data
 }
 
+export async function fetchExperimentApi(
+  workspace_id: string,
+): Promise<ExperimentDTO> {
+  const response = await axios.get(
+    `${BASE_URL}/experiments/fetch/${workspace_id}`,
+  )
+  return response.data
+}
+
 export async function renameExperiment(
   workspaceId: number,
   uid: string,

--- a/frontend/src/api/experiments/Experiments.ts
+++ b/frontend/src/api/experiments/Experiments.ts
@@ -103,7 +103,7 @@ export async function downloadExperimentConfigApi(
 }
 
 export async function fetchExperimentApi(
-  workspace_id: string,
+  workspace_id: number,
 ): Promise<ExperimentDTO> {
   const response = await axios.get(
     `${BASE_URL}/experiments/fetch/${workspace_id}`,

--- a/frontend/src/api/experiments/Experiments.ts
+++ b/frontend/src/api/experiments/Experiments.ts
@@ -27,7 +27,7 @@ export type ExperimentDTO = {
   success?: EXPERIMENTS_STATUS
   started_at: string
   finished_at?: string
-  workspace_id: string
+  workspace_id: number
   unique_id: string
   hasNWB: boolean
   edgeDict: EdgeDict
@@ -35,14 +35,14 @@ export type ExperimentDTO = {
 }
 
 export async function getExperimentsApi(
-  workspaceId: string,
+  workspaceId: number,
 ): Promise<ExperimentsDTO> {
   const response = await axios.get(`${BASE_URL}/experiments/${workspaceId}`)
   return response.data
 }
 
 export async function deleteExperimentByUidApi(
-  workspaceId: string,
+  workspaceId: number,
   uid: string,
 ): Promise<boolean> {
   const response = await axios.delete(
@@ -52,7 +52,7 @@ export async function deleteExperimentByUidApi(
 }
 
 export async function deleteExperimentByListApi(
-  workspaceId: string,
+  workspaceId: number,
   uidList: Array<string>,
 ): Promise<boolean> {
   const response = await axios.post(
@@ -65,7 +65,7 @@ export async function deleteExperimentByListApi(
 }
 
 export async function importExperimentByUidApi(
-  workspaceId: string,
+  workspaceId: number,
   uid: string,
 ): Promise<RunPostData> {
   const response = await axios.get(
@@ -75,7 +75,7 @@ export async function importExperimentByUidApi(
 }
 
 export async function downloadExperimentNwbApi(
-  workspaceId: string,
+  workspaceId: number,
   uid: string,
   nodeId?: string,
 ) {
@@ -90,7 +90,7 @@ export async function downloadExperimentNwbApi(
 }
 
 export async function downloadExperimentConfigApi(
-  workspaceId: string,
+  workspaceId: number,
   uid: string,
 ) {
   const response = await axios.get(
@@ -103,7 +103,7 @@ export async function downloadExperimentConfigApi(
 }
 
 export async function renameExperiment(
-  workspaceId: string,
+  workspaceId: number,
   uid: string,
   new_name: string,
 ) {

--- a/frontend/src/api/run/Run.ts
+++ b/frontend/src/api/run/Run.ts
@@ -43,7 +43,7 @@ export interface AlgorithmNodePostData extends AlgorithmNodeData {
 }
 
 export async function runApi(
-  workspaceId: string,
+  workspaceId: number,
   data: RunPostData,
 ): Promise<string> {
   const response = await axios.post(`${BASE_URL}/run/${workspaceId}`, data)
@@ -51,7 +51,7 @@ export async function runApi(
 }
 
 export async function runByUidApi(
-  workspaceId: string,
+  workspaceId: number,
   uid: string,
   data: Omit<RunPostData, 'name'>,
 ): Promise<string> {
@@ -79,7 +79,7 @@ export type OutputPathsDTO = {
 }
 
 export async function runResult(data: {
-  workspaceId: string
+  workspaceId: number
   uid: string
   pendingNodeIdList: string[]
 }): Promise<RunResultDTO> {

--- a/frontend/src/components/Workspace/Experiment/ExperimentTable.tsx
+++ b/frontend/src/components/Workspace/Experiment/ExperimentTable.tsx
@@ -53,7 +53,10 @@ import { styled } from '@mui/material/styles'
 import { renameExperiment } from 'api/experiments/Experiments'
 import { selectPipelineLatestUid } from 'store/slice/Pipeline/PipelineSelectors'
 import { clearCurrentPipeline } from 'store/slice/Pipeline/PipelineSlice'
-import { selectCurrentWorkspaceId } from 'store/slice/Workspace/WorkspaceSelector'
+import {
+  selectCurrentWorkspaceId,
+  selectIsWorkspaceOwner,
+} from 'store/slice/Workspace/WorkspaceSelector'
 
 export const ExperimentUidContext = React.createContext<string>('')
 
@@ -90,6 +93,7 @@ const ExperimentsErrorView: React.FC = () => {
 const LOCAL_STORAGE_KEY_PER_PAGE = 'optinist_experiment_table_per_page'
 
 const TableImple = React.memo(() => {
+  const isOwner = useSelector(selectIsWorkspaceOwner)
   const currentPipelineUid = useSelector(selectPipelineLatestUid)
   const experimentList = useSelector(selectExperimentList)
   const experimentListValues = Object.values(experimentList)
@@ -195,18 +199,20 @@ const TableImple = React.memo(() => {
         >
           Reload
         </Button>
-        <Button
-          sx={{
-            marginBottom: (theme) => theme.spacing(1),
-          }}
-          variant="outlined"
-          color="error"
-          endIcon={<DeleteIcon />}
-          onClick={onClickDelete}
-          disabled={checkedList.length === 0}
-        >
-          Delete
-        </Button>
+        {isOwner && (
+          <Button
+            sx={{
+              marginBottom: (theme) => theme.spacing(1),
+            }}
+            variant="outlined"
+            color="error"
+            endIcon={<DeleteIcon />}
+            onClick={onClickDelete}
+            disabled={checkedList.length === 0}
+          >
+            Delete
+          </Button>
+        )}
       </Box>
       <Dialog open={open}>
         <DialogTitle>Are you sure you want to delete?</DialogTitle>
@@ -241,6 +247,7 @@ const TableImple = React.memo(() => {
               }
               onChangeAllCheck={onChangeAllCheck}
               checkboxVisible={!recordsIsEmpty}
+              isOwner={isOwner}
             />
             <TableBody>
               {experimentListValues
@@ -254,6 +261,7 @@ const TableImple = React.memo(() => {
                     <RowItem
                       onCheckBoxClick={onCheckBoxClick}
                       checked={checkedList.includes(expData.uid)}
+                      isOwner={isOwner}
                     />
                   </ExperimentUidContext.Provider>
                 ))}
@@ -309,6 +317,7 @@ const HeadItem = React.memo<{
   onChangeAllCheck: (checked: boolean) => void
   allCheckIndeterminate: boolean
   checkboxVisible: boolean
+  isOwner: boolean
 }>(
   ({
     order,
@@ -317,6 +326,7 @@ const HeadItem = React.memo<{
     onChangeAllCheck,
     allCheckIndeterminate,
     checkboxVisible,
+    isOwner,
   }) => {
     return (
       <TableHead>
@@ -361,7 +371,7 @@ const HeadItem = React.memo<{
           <TableCell>Reproduce</TableCell>
           <TableCell>SnakeFile</TableCell>
           <TableCell>NWB</TableCell>
-          <TableCell>Delete</TableCell>
+          {isOwner && <TableCell>Delete</TableCell>}
         </TableRow>
       </TableHead>
     )
@@ -371,7 +381,8 @@ const HeadItem = React.memo<{
 const RowItem = React.memo<{
   onCheckBoxClick: (uid: string) => void
   checked: boolean
-}>(({ onCheckBoxClick, checked }) => {
+  isOwner: boolean
+}>(({ onCheckBoxClick, checked, isOwner }) => {
   const workspaceId = useSelector(selectCurrentWorkspaceId)
   const uid = React.useContext(ExperimentUidContext)
   const timestamp = useSelector(selectExperimentTimeStamp(uid))
@@ -471,9 +482,7 @@ const RowItem = React.memo<{
         <TableCell>
           <NWBDownloadButton name={uid} hasNWB={hasNWB} />
         </TableCell>
-        <TableCell>
-          <DeleteButton />
-        </TableCell>
+        {isOwner &&<TableCell> <DeleteButton /></TableCell>}
       </TableRow>
       <CollapsibleTable open={open} />
     </React.Fragment>

--- a/frontend/src/components/Workspace/RunButtons.tsx
+++ b/frontend/src/components/Workspace/RunButtons.tsx
@@ -31,7 +31,7 @@ import { setRunBtnOption } from 'store/slice/Pipeline/PipelineSlice'
 export const RunButtons = React.memo<UseRunPipelineReturnType>((props) => {
   const {
     uid,
-    isStartedSuccess,
+    runDisabled,
     filePathIsUndefined,
     algorithmNodeNotExist,
     handleCancelPipeline,
@@ -103,7 +103,7 @@ export const RunButtons = React.memo<UseRunPipelineReturnType>((props) => {
         }}
         variant="contained"
         ref={anchorRef}
-        disabled={isStartedSuccess}
+        disabled={runDisabled}
       >
         <Button onClick={handleClick}>{RUN_BTN_LABELS[runBtnOption]}</Button>
         <Button size="small" onClick={handleToggle}>

--- a/frontend/src/const/Mode.ts
+++ b/frontend/src/const/Mode.ts
@@ -1,2 +1,2 @@
 export const IS_STANDALONE = !(process.env.REACT_APP_IS_STANDALONE === 'false')
-export const STANDALONE_WORKSPACE_ID = 'default'
+export const STANDALONE_WORKSPACE_ID = 1

--- a/frontend/src/pages/Workspace/Workspace.tsx
+++ b/frontend/src/pages/Workspace/Workspace.tsx
@@ -1,36 +1,15 @@
-import React, { useEffect } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
-import { useParams } from 'react-router-dom'
+import React from 'react'
+import { useSelector } from 'react-redux'
 import { Box } from '@mui/material'
 import { styled } from '@mui/material/styles'
-import { STANDALONE_WORKSPACE_ID, IS_STANDALONE } from 'const/Mode'
 import { useRunPipeline } from 'store/slice/Pipeline/PipelineHook'
 import Experiment from 'components/Workspace/Experiment/Experiment'
 import FlowChart from 'components/Workspace/FlowChart/FlowChart'
 import Visualize from 'components/Workspace/Visualize/Visualize'
-import {
-  clearCurrentWorkspace,
-  setCurrentWorkspace,
-} from 'store/slice/Workspace/WorkspaceSlice'
 import { selectActiveTab } from 'store/slice/Workspace/WorkspaceSelector'
 
 const Workspace: React.FC = () => {
-  const dispatch = useDispatch()
   const runPipeline = useRunPipeline() // タブ切り替えによって結果取得処理が止まってしまうのを回避するため、タブの親レイヤーで呼び出している
-
-  const { workspaceId } = useParams<{ workspaceId: string }>()
-
-  useEffect(() => {
-    if (IS_STANDALONE) {
-      dispatch(setCurrentWorkspace(STANDALONE_WORKSPACE_ID))
-    } else {
-      workspaceId && dispatch(setCurrentWorkspace(workspaceId))
-    }
-    return () => {
-      dispatch(clearCurrentWorkspace())
-    }
-  }, [workspaceId, dispatch])
-
   const activeTab = useSelector(selectActiveTab)
 
   return (

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -18,7 +18,7 @@ import {
   GridRowModel,
   GridRowModes,
 } from '@mui/x-data-grid-pro'
-import { Link, useSearchParams } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import Loading from '../../components/common/Loading'
 import {
   selectIsLoadingWorkspaceList,
@@ -60,6 +60,8 @@ const columns = (
   handleOpenPopupShare: (id: number) => void,
   handleOpenPopupDel: (id: number) => void,
   handleDownload: (id: number) => void,
+  handleNavWorkflow: (id: number) => void,
+  handleNavResult: (id: number) => void,
   user?: UserDTO,
   onEdit?: (id: number) => void,
 ) => [
@@ -141,8 +143,8 @@ const columns = (
     minWidth: 160,
     filterable: false, // todo enable when api complete
     sortable: false, // todo enable when api complete
-    renderCell: (params: GridRenderCellParams<string>) => (
-      <LinkCustom to={'#'}>Workflow</LinkCustom>
+    renderCell: (params: GridRenderCellParams<number>) => (
+      <ButtonCustom onClick={() => handleNavWorkflow(params.row.id)}>Workflow</ButtonCustom>
     ),
   },
   {
@@ -151,9 +153,11 @@ const columns = (
     minWidth: 130,
     filterable: false, // todo enable when api complete
     sortable: false, // todo enable when api complete
-    renderCell: (_params: GridRenderCellParams<string>) => (
-      <LinkCustom to={'#'}>Result</LinkCustom>
-    ),
+    renderCell: (params: GridRenderCellParams<number>) => {
+      return (
+      <ButtonCustom onClick={() => handleNavResult(params.row.id)}>Result</ButtonCustom>
+      )
+    }
   },
   {
     field: 'download',
@@ -248,6 +252,7 @@ const PopupDelete = ({open, handleClose, handleOkDel}: PopupType) => {
 
 const Workspaces = () => {
   const dispatch = useDispatch()
+  const navigate = useNavigate()
   const loading = useSelector(selectIsLoadingWorkspaceList)
   const listUserShare = useSelector(selectWorkspaceListUserShare)
   const data = useSelector(selectWorkspaceData)
@@ -317,6 +322,14 @@ const Workspaces = () => {
   const handleClosePopupNew = () => {
     setOpen({ ...open, new: false })
     setError('')
+  }
+
+  const handleNavWorkflow = (id: number) => {
+    navigate(`/console/workspaces/${id}`)
+  }
+
+  const handleNavResult = (id: number) => {
+    navigate(`/console/workspaces/${id}`, { state: { tab: 2 } })
   }
 
   const onEditName = (id: number) => {
@@ -447,6 +460,8 @@ const Workspaces = () => {
                   handleOpenPopupShare,
                   handleOpenPopupDel,
                   handleDownload,
+                  handleNavWorkflow,
+                  handleNavResult,
                   user,
                   onEditName,
                 ).filter(Boolean) as any
@@ -520,18 +535,6 @@ const ButtonCustom = styled(Button)(({ theme }) => ({
   },
 }))
 
-const LinkCustom = styled(Link)(({ theme }) => ({
-  backgroundColor: '#000000c4',
-  color: '#FFF',
-  fontSize: 16,
-  padding: theme.spacing(0.5, 1.5),
-  textTransform: 'unset',
-  textDecoration: 'unset',
-  borderRadius: 5,
-  '&:hover': {
-    backgroundColor: '#000000fc',
-  },
-}))
 
 const ButtonIcon = styled('button')(({ theme }) => ({
   minWidth: '32px',

--- a/frontend/src/store/slice/AlgorithmNode/AlgorithmNodeSlice.ts
+++ b/frontend/src/store/slice/AlgorithmNode/AlgorithmNodeSlice.ts
@@ -6,7 +6,10 @@ import {
   deleteFlowNodeById,
 } from '../FlowElement/FlowElementSlice'
 import { NODE_TYPE_SET } from '../FlowElement/FlowElementType'
-import { importExperimentByUid } from '../Experiments/ExperimentsActions'
+import {
+  fetchExperiment,
+  importExperimentByUid,
+} from '../Experiments/ExperimentsActions'
 import { getAlgoParams } from './AlgorithmNodeActions'
 import { ALGORITHM_NODE_SLICE_NAME, AlgorithmNode } from './AlgorithmNodeType'
 import { isAlgorithmNodePostData } from 'api/run/RunUtils'
@@ -68,22 +71,25 @@ export const algorithmNodeSlice = createSlice({
           delete state[action.payload]
         }
       })
-      .addCase(importExperimentByUid.fulfilled, (_, action) => {
-        const newState: AlgorithmNode = {}
-        Object.values(action.payload.nodeDict)
-          .filter(isAlgorithmNodePostData)
-          .forEach((node) => {
-            if (node.data != null) {
-              newState[node.id] = {
-                name: node.data.label,
-                functionPath: node.data.path,
-                params: node.data.param,
-                isUpdated: false,
+      .addMatcher(
+        isAnyOf(importExperimentByUid.fulfilled, fetchExperiment.fulfilled),
+        (_, action) => {
+          const newState: AlgorithmNode = {}
+          Object.values(action.payload.nodeDict)
+            .filter(isAlgorithmNodePostData)
+            .forEach((node) => {
+              if (node.data != null) {
+                newState[node.id] = {
+                  name: node.data.label,
+                  functionPath: node.data.path,
+                  params: node.data.param,
+                  isUpdated: false,
+                }
               }
-            }
-          })
-        return newState
-      })
+            })
+          return newState
+        },
+      )
       .addMatcher(
         isAnyOf(run.fulfilled, runByCurrentUid.fulfilled),
         (state, action) => {

--- a/frontend/src/store/slice/Experiments/ExperimentsActions.ts
+++ b/frontend/src/store/slice/Experiments/ExperimentsActions.ts
@@ -82,7 +82,7 @@ export const importExperimentByUid = createAsyncThunk<
   },
 )
 
-export const fetchExperiment = createAsyncThunk<ExperimentDTO, string>(
+export const fetchExperiment = createAsyncThunk<ExperimentDTO, number>(
   `${EXPERIMENTS_SLICE_NAME}/fetchExperiment`,
   async (workspaceId, thunkAPI) => {
     try {

--- a/frontend/src/store/slice/Experiments/ExperimentsActions.ts
+++ b/frontend/src/store/slice/Experiments/ExperimentsActions.ts
@@ -1,10 +1,12 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
 import {
+  ExperimentDTO,
   ExperimentsDTO,
   getExperimentsApi,
   deleteExperimentByUidApi,
   importExperimentByUidApi,
   deleteExperimentByListApi,
+  fetchExperimentApi,
 } from 'api/experiments/Experiments'
 import { RunPostData } from 'api/run/Run'
 import { EXPERIMENTS_SLICE_NAME } from './ExperimentsType'
@@ -73,6 +75,18 @@ export const importExperimentByUid = createAsyncThunk<
   async ({ workspaceId, uid }, thunkAPI) => {
     try {
       const response = await importExperimentByUidApi(workspaceId, uid)
+      return response
+    } catch (e) {
+      return thunkAPI.rejectWithValue(e)
+    }
+  },
+)
+
+export const fetchExperiment = createAsyncThunk<ExperimentDTO, string>(
+  `${EXPERIMENTS_SLICE_NAME}/fetchExperiment`,
+  async (workspaceId, thunkAPI) => {
+    try {
+      const response = await fetchExperimentApi(workspaceId)
       return response
     } catch (e) {
       return thunkAPI.rejectWithValue(e)

--- a/frontend/src/store/slice/Experiments/ExperimentsActions.ts
+++ b/frontend/src/store/slice/Experiments/ExperimentsActions.ts
@@ -67,7 +67,7 @@ export const deleteExperimentByList = createAsyncThunk<
 
 export const importExperimentByUid = createAsyncThunk<
   RunPostData,
-  { workspaceId: string; uid: string }
+  { workspaceId: number; uid: string }
 >(
   `${EXPERIMENTS_SLICE_NAME}/importExperimentByUid`,
   async ({ workspaceId, uid }, thunkAPI) => {

--- a/frontend/src/store/slice/Experiments/ExperimentsSlice.ts
+++ b/frontend/src/store/slice/Experiments/ExperimentsSlice.ts
@@ -23,7 +23,9 @@ export const initialState: Experiments = {
 export const experimentsSlice = createSlice({
   name: EXPERIMENTS_SLICE_NAME,
   initialState: initialState as Experiments,
-  reducers: {},
+  reducers: {
+    clearExperiments: () => initialState,
+  },
   extraReducers: (builder) => {
     builder
       .addCase(getExperiments.pending, () => {
@@ -81,4 +83,5 @@ export const experimentsSlice = createSlice({
   },
 })
 
+export const { clearExperiments } = experimentsSlice.actions
 export default experimentsSlice.reducer

--- a/frontend/src/store/slice/Experiments/ExperimentsSlice.ts
+++ b/frontend/src/store/slice/Experiments/ExperimentsSlice.ts
@@ -4,8 +4,12 @@ import {
   getExperiments,
   deleteExperimentByUid,
   deleteExperimentByList,
+  fetchExperiment,
 } from './ExperimentsActions'
-import { convertToExperimentListType } from './ExperimentsUtils'
+import {
+  convertToExperimentListType,
+  convertToExperimentType,
+} from './ExperimentsUtils'
 import {
   pollRunResult,
   run,
@@ -61,6 +65,12 @@ export const experimentsSlice = createSlice({
               target.functions[nodeId].status = 'error'
             }
           })
+        }
+      })
+      .addCase(fetchExperiment.fulfilled, (state, action) => {
+        if (state.status === 'fulfilled') {
+          state.experimentList[action.payload.unique_id] =
+            convertToExperimentType(action.payload)
         }
       })
       .addMatcher(isAnyOf(run.fulfilled, runByCurrentUid.fulfilled), () => {

--- a/frontend/src/store/slice/Experiments/ExperimentsUtils.ts
+++ b/frontend/src/store/slice/Experiments/ExperimentsUtils.ts
@@ -1,4 +1,9 @@
-import type { ExperimentDTO, ExperimentsDTO } from 'api/experiments/Experiments'
+import type {
+  ExperimentDTO,
+  ExperimentsDTO,
+  FunctionsDTO,
+} from 'api/experiments/Experiments'
+import { RunResultDTO } from 'api/run/Run'
 import type {
   ExperimentListType,
   ExperimentType,
@@ -47,6 +52,21 @@ function convertToExperimentStatus(dto: string): EXPERIMENTS_STATUS {
     default:
       throw new Error('failed to convert to EXPERIMENTS_STATUS')
   }
+}
+
+export function convertFunctionsToRunResultDTO(
+  dto: FunctionsDTO,
+): RunResultDTO {
+  const result: RunResultDTO = {}
+  Object.entries(dto).forEach(([nodeId, value]) => {
+    result[nodeId] = {
+      status: value.success,
+      message: value.message ?? '',
+      name: value.name,
+      outputPaths: value.outputPaths,
+    }
+  })
+  return result
 }
 
 export function convertToFlowChartList(

--- a/frontend/src/store/slice/FlowElement/FlowElementSlice.ts
+++ b/frontend/src/store/slice/FlowElement/FlowElementSlice.ts
@@ -103,6 +103,18 @@ export const flowElementSlice = createSlice({
           [{ id: element.id, type: 'remove' }],
           state.flowNodes,
         )
+        state.flowEdges = applyEdgeChanges(
+          state.flowEdges
+            .filter((edge) => {
+              return (
+                edge.source === action.payload || edge.target === action.payload
+              )
+            })
+            .map((edge) => {
+              return { id: edge.id, type: 'remove' }
+            }),
+          state.flowEdges,
+        )
       }
     },
     editFlowNodePositionById: (

--- a/frontend/src/store/slice/Pipeline/PipelineHook.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineHook.ts
@@ -27,6 +27,7 @@ import {
   setActiveTab,
   setCurrentWorkspace,
 } from '../Workspace/WorkspaceSlice'
+import { clearExperiments } from '../Experiments/ExperimentsSlice'
 
 const POLLING_INTERVAL = 5000
 
@@ -58,6 +59,7 @@ export function useRunPipeline() {
       }
     }
     return () => {
+      dispatch(clearExperiments())
       dispatch(clearCurrentWorkspace())
     }
   }, [dispatch, navigate, workspaceExists, _workspaceId, location.state])

--- a/frontend/src/store/slice/Pipeline/PipelineHook.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineHook.ts
@@ -19,7 +19,6 @@ import {
 import { useSnackbar } from 'notistack'
 import { RUN_STATUS } from './PipelineType'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
-import { selectCurrentUser } from '../User/UserSelector'
 import { IS_STANDALONE, STANDALONE_WORKSPACE_ID } from 'const/Mode'
 import {
   clearCurrentWorkspace,
@@ -29,8 +28,7 @@ import {
 import { clearExperiments } from '../Experiments/ExperimentsSlice'
 import { AppDispatch } from 'store/store'
 import { getWorkspace } from '../Workspace/WorkspacesActions'
-import { isMe } from 'utils/checkRole'
-import { selectCurrentWorkspaceOwnerId } from '../Workspace/WorkspaceSelector'
+import { selectIsWorkspaceOwner } from '../Workspace/WorkspaceSelector'
 
 const POLLING_INTERVAL = 5000
 
@@ -44,7 +42,6 @@ export function useRunPipeline() {
 
   const { workspaceId } = useParams<{ workspaceId: string }>()
   const _workspaceId = Number(workspaceId)
-  const currentUser = useSelector(selectCurrentUser)
 
   React.useEffect(() => {
     if (IS_STANDALONE) {
@@ -68,11 +65,10 @@ export function useRunPipeline() {
   }, [dispatch, appDispatch, navigate, _workspaceId, location.state])
 
   const uid = useSelector(selectPipelineLatestUid)
-  const ownerId = useSelector(selectCurrentWorkspaceOwnerId)
   const isCanceled = useSelector(selectPipelineIsCanceled)
   const isStartedSuccess = useSelector(selectPipelineIsStartedSuccess)
-  const runDisabled =
-    IS_STANDALONE || isMe(currentUser, ownerId) ? isStartedSuccess : true
+  const isOwner = useSelector(selectIsWorkspaceOwner)
+  const runDisabled = isOwner ? isStartedSuccess : true
 
   const filePathIsUndefined = useSelector(selectFilePathIsUndefined)
   const algorithmNodeNotExist = useSelector(selectAlgorithmNodeNotExist)

--- a/frontend/src/store/slice/Pipeline/PipelineSlice.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineSlice.ts
@@ -1,5 +1,8 @@
 import { createSlice, isAnyOf, PayloadAction } from '@reduxjs/toolkit'
-import { importExperimentByUid } from '../Experiments/ExperimentsActions'
+import {
+  fetchExperiment,
+  importExperimentByUid,
+} from '../Experiments/ExperimentsActions'
 import { pollRunResult, run, runByCurrentUid } from './PipelineActions'
 import {
   Pipeline,
@@ -14,6 +17,7 @@ import {
   convertToRunResult,
   isNodeResultPending,
 } from './PipelineUtils'
+import { convertFunctionsToRunResultDTO } from '../Experiments/ExperimentsUtils'
 
 const initialState: Pipeline = {
   run: {
@@ -66,6 +70,37 @@ export const pipelineSlice = createSlice({
         state.runBtn = RUN_BTN_OPTIONS.RUN_ALREADY
         state.run = {
           status: RUN_STATUS.START_UNINITIALIZED,
+        }
+      })
+      .addCase(fetchExperiment.rejected, () => initialState)
+      .addCase(fetchExperiment.fulfilled, (state, action) => {
+        state.currentPipeline = {
+          uid: action.payload.unique_id,
+        }
+        state.runBtn = RUN_BTN_OPTIONS.RUN_ALREADY
+        state.run = {
+          uid: action.payload.unique_id,
+          status: RUN_STATUS.START_SUCCESS,
+          runResult: {
+            ...convertToRunResult(
+              convertFunctionsToRunResultDTO(action.payload.function),
+            ),
+          },
+          runPostData: {
+            name: action.payload.name,
+            nodeDict: action.payload.nodeDict,
+            edgeDict: action.payload.edgeDict,
+            snakemakeParam: {},
+            nwbParam: {},
+            forceRunList: [],
+          },
+        }
+
+        const runResultPendingList = Object.values(state.run.runResult).filter(
+          isNodeResultPending,
+        )
+        if (runResultPendingList.length === 0) {
+          state.run.status = RUN_STATUS.FINISHED
         }
       })
       .addMatcher(

--- a/frontend/src/store/slice/Pipeline/PipelineUtils.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineUtils.ts
@@ -67,6 +67,11 @@ export function convertToRunResult(dto: RunResultDTO) {
         name: nodeResultDto.name,
         outputPaths: convertToOutputPath(outputPath),
       }
+    } else if (nodeResultDto.status === 'running') {
+      result[nodeId] = {
+        status: NODE_RESULT_STATUS.PENDING,
+        name: nodeResultDto.name,
+      }
     } else {
       result[nodeId] = {
         status: NODE_RESULT_STATUS.ERROR,

--- a/frontend/src/store/slice/RightDrawer/RightDrawerSlice.ts
+++ b/frontend/src/store/slice/RightDrawer/RightDrawerSlice.ts
@@ -1,5 +1,8 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit'
-import { importExperimentByUid } from '../Experiments/ExperimentsActions'
+import { createSlice, isAnyOf, PayloadAction } from '@reduxjs/toolkit'
+import {
+  fetchExperiment,
+  importExperimentByUid,
+} from '../Experiments/ExperimentsActions'
 import {
   deleteFlowNodes,
   deleteFlowNodeById,
@@ -19,7 +22,7 @@ export const RIGHT_DRAWER_MODE = {
 } as const
 
 export type RIGHT_DRAWER_MODE_TYPE =
-  (typeof RIGHT_DRAWER_MODE)[keyof typeof RIGHT_DRAWER_MODE]
+  typeof RIGHT_DRAWER_MODE[keyof typeof RIGHT_DRAWER_MODE]
 
 const initialState: RightDrawer = {
   open: false,
@@ -91,6 +94,10 @@ export const rightDrawerSlice = createSlice({
       .addCase(importExperimentByUid.fulfilled, () => {
         return initialState
       })
+      .addMatcher(
+        isAnyOf(fetchExperiment.fulfilled, fetchExperiment.rejected),
+        () => initialState,
+      )
   },
 })
 

--- a/frontend/src/store/slice/User/UserSelector.ts
+++ b/frontend/src/store/slice/User/UserSelector.ts
@@ -2,6 +2,8 @@ import { ROLE } from '@types'
 import { RootState } from 'store/store'
 
 export const selectCurrentUser = (state: RootState) => state.user.currentUser
+export const selectCurrentUserId = (state: RootState) =>
+  selectCurrentUser(state)?.id
 export const selectCurrentUserUid = (state: RootState) =>
   selectCurrentUser(state)?.uid
 export const selectCurrentUserEmail = (state: RootState) =>

--- a/frontend/src/store/slice/Workspace/WorkspaceSelector.ts
+++ b/frontend/src/store/slice/Workspace/WorkspaceSelector.ts
@@ -1,3 +1,4 @@
+import { IS_STANDALONE } from 'const/Mode'
 import { RootState } from 'store/store'
 
 export const selectWorkspace = (state: RootState) => state.workspace
@@ -21,3 +22,8 @@ export const selectCurrentWorkspaceOwnerId = (state: RootState) =>
 
 export const selectIsLoadingWorkspaceList = (state: RootState) =>
   state.workspace.loading
+
+export const selectIsWorkspaceOwner = (state: RootState) =>
+  IS_STANDALONE
+    ? true
+    : state.workspace.currentWorkspace.ownerId === state.user.currentUser?.id

--- a/frontend/src/store/slice/Workspace/WorkspaceSelector.ts
+++ b/frontend/src/store/slice/Workspace/WorkspaceSelector.ts
@@ -1,4 +1,3 @@
-import { IS_STANDALONE } from 'const/Mode'
 import { RootState } from 'store/store'
 
 export const selectWorkspace = (state: RootState) => state.workspace
@@ -11,21 +10,14 @@ export const selectWorkspaceItem =
   (workspaceId: number) => (state: RootState) =>
     selectWorkspaceData(state).items.find((item) => item.id === workspaceId)
 
-export const selectWorkspaceItemExists =
-  (workspaceId?: number) => (state: RootState) =>
-    workspaceId && selectWorkspaceItem(workspaceId)(state) !== void 0
-
-export const selectIsCurrentUserOwnerWorkspaceItem =
-  (workspaceId: number, userId?: number) => (state: RootState) =>
-    IS_STANDALONE
-      ? true
-      : selectWorkspaceItem(workspaceId)(state)?.user.id === userId
-
 export const selectActiveTab = (state: RootState) =>
   state.workspace.currentWorkspace.selectedTab
 
 export const selectCurrentWorkspaceId = (state: RootState) =>
   state.workspace.currentWorkspace.workspaceId
+
+export const selectCurrentWorkspaceOwnerId = (state: RootState) =>
+  state.workspace.currentWorkspace.ownerId
 
 export const selectIsLoadingWorkspaceList = (state: RootState) =>
   state.workspace.loading

--- a/frontend/src/store/slice/Workspace/WorkspaceSelector.ts
+++ b/frontend/src/store/slice/Workspace/WorkspaceSelector.ts
@@ -1,8 +1,25 @@
+import { IS_STANDALONE } from 'const/Mode'
 import { RootState } from 'store/store'
 
 export const selectWorkspace = (state: RootState) => state.workspace
-export const selectWorkspaceData = (state: RootState) => state.workspace.workspace
-export const selectWorkspaceListUserShare = (state: RootState) => state.workspace.listUserShare
+export const selectWorkspaceListUserShare = (state: RootState) =>
+  state.workspace.listUserShare
+export const selectWorkspaceData = (state: RootState) =>
+  state.workspace.workspace
+
+export const selectWorkspaceItem =
+  (workspaceId: number) => (state: RootState) =>
+    selectWorkspaceData(state).items.find((item) => item.id === workspaceId)
+
+export const selectWorkspaceItemExists =
+  (workspaceId?: number) => (state: RootState) =>
+    workspaceId && selectWorkspaceItem(workspaceId)(state) !== void 0
+
+export const selectIsCurrentUserOwnerWorkspaceItem =
+  (workspaceId: number, userId?: number) => (state: RootState) =>
+    IS_STANDALONE
+      ? true
+      : selectWorkspaceItem(workspaceId)(state)?.user.id === userId
 
 export const selectActiveTab = (state: RootState) =>
   state.workspace.currentWorkspace.selectedTab

--- a/frontend/src/store/slice/Workspace/WorkspaceSlice.ts
+++ b/frontend/src/store/slice/Workspace/WorkspaceSlice.ts
@@ -31,7 +31,7 @@ export const workspaceSlice = createSlice({
     setActiveTab: (state, action: PayloadAction<number>) => {
       state.currentWorkspace.selectedTab = action.payload
     },
-    setCurrentWorkspace: (state, action: PayloadAction<string>) => {
+    setCurrentWorkspace: (state, action: PayloadAction<number>) => {
       state.currentWorkspace.workspaceId = action.payload
     },
     clearCurrentWorkspace: (state) => {

--- a/frontend/src/store/slice/Workspace/WorkspaceSlice.ts
+++ b/frontend/src/store/slice/Workspace/WorkspaceSlice.ts
@@ -4,6 +4,7 @@ import { importExperimentByUid } from '../Experiments/ExperimentsActions'
 import {
   delWorkspace,
   getListUserShareWorkSpaces,
+  getWorkspace,
   getWorkspaceList,
   postListUserShareWorkspaces,
   postWorkspace,
@@ -21,7 +22,7 @@ const initialState: Workspace = {
     offset: 0,
   },
   loading: false,
-  listUserShare: undefined
+  listUserShare: undefined,
 }
 
 export const workspaceSlice = createSlice({
@@ -45,6 +46,11 @@ export const workspaceSlice = createSlice({
       .addCase(importExperimentByUid.fulfilled, (state, action) => {
         state.currentWorkspace.workspaceId = action.meta.arg.workspaceId
       })
+      .addCase(getWorkspace.fulfilled, (state, action) => {
+        state.currentWorkspace.workspaceId = action.payload.id
+        state.currentWorkspace.ownerId = action.payload.user.id
+        state.loading = false
+      })
       .addCase(getWorkspaceList.fulfilled, (state, action) => {
         state.workspace = action.payload
         state.loading = false
@@ -55,6 +61,7 @@ export const workspaceSlice = createSlice({
       })
       .addMatcher(
         isAnyOf(
+          getWorkspace.rejected,
           getWorkspaceList.rejected,
           postWorkspace.fulfilled,
           postWorkspace.rejected,
@@ -63,7 +70,7 @@ export const workspaceSlice = createSlice({
           delWorkspace.fulfilled,
           delWorkspace.rejected,
           getListUserShareWorkSpaces.rejected,
-          postListUserShareWorkspaces.rejected
+          postListUserShareWorkspaces.rejected,
         ),
         (state) => {
           state.loading = false
@@ -71,12 +78,13 @@ export const workspaceSlice = createSlice({
       )
       .addMatcher(
         isAnyOf(
+          getWorkspace.pending,
           getWorkspaceList.pending,
           postWorkspace.pending,
           putWorkspace.pending,
           delWorkspace.pending,
           getListUserShareWorkSpaces.pending,
-          postListUserShareWorkspaces.pending
+          postListUserShareWorkspaces.pending,
         ),
         (state) => {
           state.loading = true

--- a/frontend/src/store/slice/Workspace/WorkspaceType.ts
+++ b/frontend/src/store/slice/Workspace/WorkspaceType.ts
@@ -1,4 +1,4 @@
-import {UserDTO} from "../../../api/users/UsersApiDTO";
+import { UserDTO } from '../../../api/users/UsersApiDTO'
 
 export const WORKSPACE_SLICE_NAME = 'workspace'
 
@@ -28,13 +28,14 @@ export type Workspace = {
   currentWorkspace: {
     workspaceId?: number
     selectedTab: number
+    ownerId?: number
   }
   loading: boolean
   listUserShare?: ListUserShareWorkspaceDTO
 }
 
 export type ListUserShareWorkSpace = {
-  id: number,
+  id: number
   name: string
   email: string
   created_at: string

--- a/frontend/src/store/slice/Workspace/WorkspaceType.ts
+++ b/frontend/src/store/slice/Workspace/WorkspaceType.ts
@@ -11,13 +11,13 @@ export type ItemsWorkspace = {
     email: string
     created_at: string
     updated_at: string
-  },
+  }
   created_at: string
   updated_at: string
 }
 
 export type WorkspaceDataDTO = {
-  items: ItemsWorkspace[],
+  items: ItemsWorkspace[]
   total: number
   limit: number
   offset: number
@@ -26,7 +26,7 @@ export type WorkspaceDataDTO = {
 export type Workspace = {
   workspace: WorkspaceDataDTO
   currentWorkspace: {
-    workspaceId?: string
+    workspaceId?: number
     selectedTab: number
   }
   loading: boolean
@@ -45,4 +45,6 @@ export type ListUserShareWorkspaceDTO = {
   users: UserDTO[]
 }
 
-export type WorkspaceParams = { [key: string]: string | undefined | number | string[] | object }
+export type WorkspaceParams = {
+  [key: string]: string | undefined | number | string[] | object
+}

--- a/frontend/src/store/slice/Workspace/WorkspacesActions.ts
+++ b/frontend/src/store/slice/Workspace/WorkspacesActions.ts
@@ -3,6 +3,7 @@ import {
   WorkspacePostDataDTO,
   delWorkspaceApi,
   exportWorkspaceApi,
+  getWorkspaceApi,
   getWorkspacesApi,
   importWorkspaceApi,
   postWorkspaceApi,
@@ -17,6 +18,19 @@ import {
   WorkspaceParams,
   WORKSPACE_SLICE_NAME,
 } from './WorkspaceType'
+
+export const getWorkspace = createAsyncThunk<ItemsWorkspace, { id: number }>(
+  `${WORKSPACE_SLICE_NAME}/getWorkspace`,
+  async (data, thunkAPI) => {
+    const { rejectWithValue } = thunkAPI
+    try {
+      const response = await getWorkspaceApi(data.id)
+      return response
+    } catch (e) {
+      return rejectWithValue(e)
+    }
+  },
+)
 
 export const getWorkspaceList = createAsyncThunk<
   WorkspaceDataDTO,
@@ -99,30 +113,39 @@ export const exportWorkspace = createAsyncThunk<void, number>(
 )
 
 export const getListUserShareWorkSpaces = createAsyncThunk<
-    ListShareDTO,
-    {id: number}
->(`${WORKSPACE_SLICE_NAME}/getListUserShareWorkSpaces`, async (params, thunkAPI) => {
-  const { rejectWithValue } = thunkAPI
-  try {
-    const response = await getListUserShareWorkspaceApi(params.id)
-    return response
-  } catch (e) {
-    return rejectWithValue(e)
-  }
-})
+  ListShareDTO,
+  { id: number }
+>(
+  `${WORKSPACE_SLICE_NAME}/getListUserShareWorkSpaces`,
+  async (params, thunkAPI) => {
+    const { rejectWithValue } = thunkAPI
+    try {
+      const response = await getListUserShareWorkspaceApi(params.id)
+      return response
+    } catch (e) {
+      return rejectWithValue(e)
+    }
+  },
+)
 
 export const postListUserShareWorkspaces = createAsyncThunk<
-    boolean,
-    {
-      id: number
-      data: {user_ids: number[]}
-    }
->(`${WORKSPACE_SLICE_NAME}/postListUserShareWorkspaces`, async (params, thunkAPI) => {
-  const { rejectWithValue } = thunkAPI
-  try {
-    const response = await postListUserShareWorkspaceApi(params.id, params.data)
-    return response
-  } catch (e) {
-    return rejectWithValue(e)
+  boolean,
+  {
+    id: number
+    data: { user_ids: number[] }
   }
-})
+>(
+  `${WORKSPACE_SLICE_NAME}/postListUserShareWorkspaces`,
+  async (params, thunkAPI) => {
+    const { rejectWithValue } = thunkAPI
+    try {
+      const response = await postListUserShareWorkspaceApi(
+        params.id,
+        params.data,
+      )
+      return response
+    } catch (e) {
+      return rejectWithValue(e)
+    }
+  },
+)

--- a/studio/app/common/core/experiment/experiment_utils.py
+++ b/studio/app/common/core/experiment/experiment_utils.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+from glob import glob
+from typing import Optional
+
+from studio.app.common.core.experiment.experiment import ExptConfig
+from studio.app.common.core.experiment.experiment_reader import ExptConfigReader
+from studio.app.common.core.utils.filepath_creater import join_filepath
+from studio.app.const import DATE_FORMAT
+from studio.app.dir_path import DIRPATH
+
+
+class ExptUtils:
+    @classmethod
+    def get_last_experiment(cls, workspace_id: str):
+        last_expt_config: Optional[ExptConfig] = None
+        config_paths = glob(
+            join_filepath(
+                [DIRPATH.OUTPUT_DIR, workspace_id, "*", DIRPATH.EXPERIMENT_YML]
+            )
+        )
+
+        for path in config_paths:
+            config = ExptConfigReader.read(path)
+            if not last_expt_config:
+                last_expt_config = config
+            elif datetime.strptime(config.started_at, DATE_FORMAT) > datetime.strptime(
+                last_expt_config.started_at, DATE_FORMAT
+            ):
+                last_expt_config = config
+        return last_expt_config

--- a/studio/app/common/routers/experiment.py
+++ b/studio/app/common/routers/experiment.py
@@ -2,11 +2,12 @@ import shutil
 from glob import glob
 from typing import Dict
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from fastapi.responses import FileResponse
 
 from studio.app.common.core.experiment.experiment import ExptConfig, ExptImportData
 from studio.app.common.core.experiment.experiment_reader import ExptConfigReader
+from studio.app.common.core.experiment.experiment_utils import ExptUtils
 from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.common.schemas.experiment import DeleteItem, RenameItem
 from studio.app.dir_path import DIRPATH
@@ -78,6 +79,16 @@ async def delete_experiment_list(workspace_id: str, deleteItem: DeleteItem):
         return True
     except Exception:
         return False
+
+
+@router.get("/fetch/{workspace_id}", response_model=ExptConfig)
+async def fetch_last_experiment(workspace_id: str):
+    print(workspace_id)
+    last_expt_config = ExptUtils.get_last_experiment(workspace_id)
+    if last_expt_config:
+        return last_expt_config
+    else:
+        raise HTTPException(status_code=404)
 
 
 @router.get("/download/config/{workspace_id}/{unique_id}")


### PR DESCRIPTION
- #21 

## 変更点

- fetch apiの追加
  - 指定したworkspaceで最後に実行されたworkflowのexperiment.yamlの情報を返す
  - frontendではfetch apiから取得した内容をworkflow画面に反映
- https://github.com/arayabrain/optinist-for-server/pull/62 で、nodeを削除した際に結合しているedgeがstateから削除されていなかったバグを修正
- Workspaces画面からWorkflow, Results画面への遷移を追加
  - 画面遷移の際にGET workflow/{id} APIを実行し、アクセス権をチェック
- Workflow画面でWorkspaceのオーナーではない場合にRUNボタンを非活性にする制御を追加

## 備考
- WorkspaceのIDの型定義がnumber, string混在していたため、numberに寄せています