### PR TITLE
inputディレクトリをworkspace idで分離

### DIFF
--- a/frontend/src/api/files/Files.ts
+++ b/frontend/src/api/files/Files.ts
@@ -32,9 +32,10 @@ export interface FileNodeDTO extends NodeBaseDTO {
 }
 
 export async function getFilesTreeApi(
+  workspaceId: number,
   fileType: FILE_TREE_TYPE,
 ): Promise<TreeNodeTypeDTO[]> {
-  const response = await axios.get(`${BASE_URL}/files`, {
+  const response = await axios.get(`${BASE_URL}/files/${workspaceId}`, {
     params: {
       file_type: fileType,
     },
@@ -43,6 +44,7 @@ export async function getFilesTreeApi(
 }
 
 export async function uploadFileApi(
+  workspaceId: number,
   fileName: string,
   config: {
     onUploadProgress: (progressEvent: any) => void
@@ -50,7 +52,7 @@ export async function uploadFileApi(
   formData: FormData,
 ): Promise<{ file_path: string }> {
   const response = await axios.post(
-    `${BASE_URL}/files/upload/${fileName}`,
+    `${BASE_URL}/files/${workspaceId}/upload/${fileName}`,
     formData,
     config,
   )

--- a/frontend/src/api/hdf5/HDF5.ts
+++ b/frontend/src/api/hdf5/HDF5.ts
@@ -19,7 +19,12 @@ export interface HDF5FileDTO {
   nbytes: string
 }
 
-export async function getHDF5TreeApi(path: string): Promise<HDF5TreeDTO[]> {
-  const response = await axios.get(`${BASE_URL}/hdf5/${path}`)
+export async function getHDF5TreeApi(
+  path: string,
+  workspaceId: number,
+): Promise<HDF5TreeDTO[]> {
+  const response = await axios.get(
+    `${BASE_URL}/hdf5/${path}?workspace_id=${workspaceId}`,
+  )
   return response.data
 }

--- a/frontend/src/api/outputs/Outputs.ts
+++ b/frontend/src/api/outputs/Outputs.ts
@@ -48,12 +48,14 @@ export type ImageData = number[][][]
 export async function getImageDataApi(
   path: string,
   params: {
+    workspaceId: number
     startIndex?: number
     endIndex?: number
   },
 ): Promise<{ data: ImageData }> {
   const response = await axios.get(`${BASE_URL}/outputs/image/${path}`, {
     params: {
+      workspace_id: params.workspaceId,
       start_index: params.startIndex,
       end_index: params.endIndex,
     },
@@ -63,15 +65,26 @@ export async function getImageDataApi(
 
 export type CsvData = number[][]
 
-export async function getCsvDataApi(path: string): Promise<{ data: CsvData }> {
-  const response = await axios.get(`${BASE_URL}/outputs/csv/${path}`)
+export async function getCsvDataApi(
+  path: string,
+  params: { workspaceId: number },
+): Promise<{ data: CsvData }> {
+  const response = await axios.get(`${BASE_URL}/outputs/csv/${path}`, {
+    params: { workspace_id: params.workspaceId },
+  })
+
   return response.data
 }
 
 export type RoiData = number[][][]
 
-export async function getRoiDataApi(path: string): Promise<{ data: RoiData }> {
-  const response = await axios.get(`${BASE_URL}/outputs/image/${path}`, {})
+export async function getRoiDataApi(
+  path: string,
+  params: { workspaceId: number },
+): Promise<{ data: RoiData }> {
+  const response = await axios.get(`${BASE_URL}/outputs/image/${path}`, {
+    params: { workspace_id: params.workspaceId },
+  })
   return response.data
 }
 

--- a/frontend/src/components/Workspace/FlowChart/FlowChartNode/CsvFileNode.tsx
+++ b/frontend/src/components/Workspace/FlowChart/FlowChartNode/CsvFileNode.tsx
@@ -37,6 +37,7 @@ import {
 } from 'store/slice/DisplayData/DisplayDataSelectors'
 import { getCsvData } from 'store/slice/DisplayData/DisplayDataActions'
 import { PresentationalCsvPlot } from 'components/Workspace/Visualize/Plot/CsvPlot'
+import { selectCurrentWorkspaceId } from 'store/slice/Workspace/WorkspaceSelector'
 
 const sourceHandleStyle: CSSProperties = {
   width: 8,
@@ -213,12 +214,13 @@ const CsvPreview = React.memo<{
   const isPending = useSelector(selectCsvDataIsPending(path))
   const isFulfilled = useSelector(selectCsvDataIsFulfilled(path))
   const error = useSelector(selectCsvDataError(path))
+  const workspaceId = useSelector(selectCurrentWorkspaceId)
   const dispatch = useDispatch()
   React.useEffect(() => {
-    if (!isInitialized) {
-      dispatch(getCsvData({ path }))
+    if (workspaceId && !isInitialized) {
+      dispatch(getCsvData({ path, workspaceId }))
     }
-  }, [dispatch, isInitialized, path])
+  }, [dispatch, isInitialized, path, workspaceId])
   if (isPending) {
     return <LinearProgress />
   } else if (error != null) {

--- a/frontend/src/components/Workspace/FlowChart/FlowChartNode/HDF5FileNode.tsx
+++ b/frontend/src/components/Workspace/FlowChart/FlowChartNode/HDF5FileNode.tsx
@@ -32,6 +32,7 @@ import {
 import { getHDF5Tree } from 'store/slice/HDF5/HDF5Action'
 import { HDF5TreeNodeType } from 'store/slice/HDF5/HDF5Type'
 import { Typography } from '@mui/material'
+import { selectCurrentWorkspaceId } from 'store/slice/Workspace/WorkspaceSelector'
 
 const sourceHandleStyle: CSSProperties = {
   width: 8,
@@ -223,10 +224,11 @@ function useHDF5Tree(
   const tree = useSelector(selectHDF5Nodes())
   const isLoading = useSelector(selectHDF5IsLoading())
   const filePath = useSelector(selectHDF5InputNodeSelectedFilePath(nodeId))
+  const workspaceId = useSelector(selectCurrentWorkspaceId)
   React.useEffect(() => {
-    if (!isLoading && filePath) {
-      dispatch(getHDF5Tree({ path: filePath }))
+    if (workspaceId && !isLoading && filePath) {
+      dispatch(getHDF5Tree({ path: filePath, workspaceId }))
     }
-  }, [isLoading, filePath, dispatch])
+  }, [workspaceId, isLoading, filePath, dispatch])
   return [tree, isLoading]
 }

--- a/frontend/src/components/Workspace/Visualize/Editor/ImageItemEditor.tsx
+++ b/frontend/src/components/Workspace/Visualize/Editor/ImageItemEditor.tsx
@@ -50,6 +50,7 @@ import Button from '@mui/material/Button'
 import { getImageData } from 'store/slice/DisplayData/DisplayDataActions'
 import { setNewDisplayDataPath } from 'store/slice/VisualizeItem/VisualizeItemActions'
 import { SaveFig } from './SaveFig'
+import { selectCurrentWorkspaceId } from 'store/slice/Workspace/WorkspaceSelector'
 
 export const ImageItemEditor: React.FC = () => {
   const itemId = React.useContext(SelectedItemIdContext)
@@ -263,6 +264,7 @@ const RoiAlpha: React.FC = () => {
 }
 
 const StartEndIndex: React.FC = () => {
+  const workspaceId = useSelector(selectCurrentWorkspaceId)
   const itemId = React.useContext(SelectedItemIdContext)
   const [startIndex, onChangeStartIndex] = React.useState(
     useSelector(selectImageItemStartIndex(itemId)),
@@ -291,9 +293,10 @@ const StartEndIndex: React.FC = () => {
       dispatch(setImageItemStartIndex({ itemId, startIndex }))
       dispatch(setImageItemEndIndex({ itemId, endIndex }))
       dispatch(resetImageActiveIndex({ itemId, startIndex, endIndex }))
-      if (filePath !== null) {
+      if (workspaceId && filePath !== null) {
         dispatch(
           getImageData({
+            workspaceId,
             path: filePath,
             startIndex: startIndex ?? 1,
             endIndex: endIndex ?? 10,

--- a/frontend/src/components/Workspace/Visualize/Plot/CsvPlot.tsx
+++ b/frontend/src/components/Workspace/Visualize/Plot/CsvPlot.tsx
@@ -19,19 +19,21 @@ import {
   selectCsvItemSetIndex,
   selectCsvItemTranspose,
 } from 'store/slice/VisualizeItem/VisualizeItemSelectors'
+import { selectCurrentWorkspaceId } from 'store/slice/Workspace/WorkspaceSelector'
 
 export const CsvPlot = React.memo(() => {
   const { filePath: path } = React.useContext(DisplayDataContext)
+  const workspaceId = useSelector(selectCurrentWorkspaceId)
   const isInitialized = useSelector(selectCsvDataIsInitialized(path))
   const isPending = useSelector(selectCsvDataIsPending(path))
   const isFulfilled = useSelector(selectCsvDataIsFulfilled(path))
   const error = useSelector(selectCsvDataError(path))
   const dispatch = useDispatch()
   React.useEffect(() => {
-    if (!isInitialized) {
-      dispatch(getCsvData({ path }))
+    if (workspaceId && !isInitialized) {
+      dispatch(getCsvData({ path, workspaceId }))
     }
-  }, [dispatch, isInitialized, path])
+  }, [dispatch, isInitialized, path, workspaceId])
   if (isPending) {
     return <LinearProgress />
   } else if (error != null) {

--- a/frontend/src/components/Workspace/Visualize/Plot/RoiPlot.tsx
+++ b/frontend/src/components/Workspace/Visualize/Plot/RoiPlot.tsx
@@ -20,6 +20,7 @@ import {
   selectVisualizeSaveFilename,
   selectVisualizeSaveFormat,
 } from 'store/slice/VisualizeItem/VisualizeItemSelectors'
+import { selectCurrentWorkspaceId } from 'store/slice/Workspace/WorkspaceSelector'
 
 export const RoiPlot = React.memo(() => {
   const { filePath: path } = React.useContext(DisplayDataContext)
@@ -27,13 +28,14 @@ export const RoiPlot = React.memo(() => {
   const isInitialized = useSelector(selectRoiDataIsInitialized(path))
   const isFulfilled = useSelector(selectRoiDataIsFulfilled(path))
   const error = useSelector(selectRoiDataError(path))
+  const workspaceId = useSelector(selectCurrentWorkspaceId)
 
   const dispatch = useDispatch()
   React.useEffect(() => {
-    if (!isInitialized) {
-      dispatch(getRoiData({ path }))
+    if (workspaceId && !isInitialized) {
+      dispatch(getRoiData({ path, workspaceId }))
     }
-  }, [dispatch, isInitialized, path])
+  }, [dispatch, isInitialized, path, workspaceId])
   if (isPending) {
     return <LinearProgress />
   } else if (error != null) {

--- a/frontend/src/components/common/FileSelectDialog.tsx
+++ b/frontend/src/components/common/FileSelectDialog.tsx
@@ -28,6 +28,7 @@ import {
   getNodeByPath,
   isDirNodeByPath,
 } from 'store/slice/FilesTree/FilesTreeUtils'
+import { selectCurrentWorkspaceId } from 'store/slice/Workspace/WorkspaceSelector'
 
 type FileSelectDialogProps = {
   initialFilePath: string[] | string
@@ -298,10 +299,11 @@ function useFileTree(
   const tree = useSelector(selectFilesTreeNodes(fileType))
   const isLatest = useSelector(selectFilesIsLatest(fileType))
   const isLoading = useSelector(selectFilesIsLoading(fileType))
+  const workspaceId = useSelector(selectCurrentWorkspaceId)
   React.useEffect(() => {
-    if (!isLatest && !isLoading) {
-      dispatch(getFilesTree(fileType))
+    if (workspaceId && !isLatest && !isLoading) {
+      dispatch(getFilesTree({workspaceId, fileType}))
     }
-  }, [isLatest, isLoading, fileType, dispatch])
+  }, [workspaceId, isLatest, isLoading, fileType, dispatch])
   return [tree, isLoading]
 }

--- a/frontend/src/store/slice/DisplayData/DisplayDataActions.ts
+++ b/frontend/src/store/slice/DisplayData/DisplayDataActions.ts
@@ -80,12 +80,16 @@ export const getHeatMapData = createAsyncThunk<
 
 export const getImageData = createAsyncThunk<
   { data: ImageData },
-  { path: string; startIndex?: number; endIndex?: number }
+  { path: string; workspaceId: number; startIndex?: number; endIndex?: number }
 >(
   `${DISPLAY_DATA_SLICE_NAME}/getImageData`,
-  async ({ path, startIndex, endIndex }, thunkAPI) => {
+  async ({ path, startIndex, endIndex, workspaceId }, thunkAPI) => {
     try {
-      const response = await getImageDataApi(path, { startIndex, endIndex })
+      const response = await getImageDataApi(path, {
+        workspaceId,
+        startIndex,
+        endIndex,
+      })
       return response
     } catch (e) {
       return thunkAPI.rejectWithValue(e)
@@ -97,21 +101,27 @@ export const getCsvData = createAsyncThunk<
   {
     data: CsvData
   },
-  { path: string }
->(`${DISPLAY_DATA_SLICE_NAME}/getCsvData`, async ({ path }, thunkAPI) => {
-  try {
-    const response = await getCsvDataApi(path)
-    return response
-  } catch (e) {
-    return thunkAPI.rejectWithValue(e)
-  }
-})
-
-export const getRoiData = createAsyncThunk<{ data: RoiData }, { path: string }>(
-  `${DISPLAY_DATA_SLICE_NAME}/getRoiData`,
-  async ({ path }, thunkAPI) => {
+  { path: string; workspaceId: number }
+>(
+  `${DISPLAY_DATA_SLICE_NAME}/getCsvData`,
+  async ({ path, workspaceId }, thunkAPI) => {
     try {
-      const response = await getRoiDataApi(path)
+      const response = await getCsvDataApi(path, { workspaceId })
+      return response
+    } catch (e) {
+      return thunkAPI.rejectWithValue(e)
+    }
+  },
+)
+
+export const getRoiData = createAsyncThunk<
+  { data: RoiData },
+  { path: string; workspaceId: number }
+>(
+  `${DISPLAY_DATA_SLICE_NAME}/getRoiData`,
+  async ({ path, workspaceId }, thunkAPI) => {
+    try {
+      const response = await getRoiDataApi(path, { workspaceId })
       return response
     } catch (e) {
       return thunkAPI.rejectWithValue(e)

--- a/frontend/src/store/slice/FileUploader/FileUploaderActions.ts
+++ b/frontend/src/store/slice/FileUploader/FileUploaderActions.ts
@@ -15,6 +15,7 @@ export const uploadFile = createAsyncThunk<
     resultPath: string
   },
   {
+    workspaceId: number
     requestId: string
     nodeId?: string
     fileName: string
@@ -23,7 +24,7 @@ export const uploadFile = createAsyncThunk<
   }
 >(
   `${FILE_UPLOADER_SLICE_NAME}/uploadFile`,
-  async ({ requestId, fileName, formData }, thunkAPI) => {
+  async ({ workspaceId, requestId, fileName, formData }, thunkAPI) => {
     try {
       const config = getUploadConfig((percent, total) => {
         thunkAPI.dispatch(
@@ -34,7 +35,12 @@ export const uploadFile = createAsyncThunk<
           }),
         )
       })
-      const response = await uploadFileApi(fileName, config, formData)
+      const response = await uploadFileApi(
+        workspaceId,
+        fileName,
+        config,
+        formData,
+      )
       return {
         resultPath: response.file_path,
       }

--- a/frontend/src/store/slice/FileUploader/FileUploaderHook.ts
+++ b/frontend/src/store/slice/FileUploader/FileUploaderHook.ts
@@ -11,6 +11,7 @@ import {
   selectFileUploadError,
 } from './FileUploaderSelectors'
 import { FILE_TYPE } from '../InputNode/InputNodeType'
+import { selectCurrentWorkspaceId } from '../Workspace/WorkspaceSelector'
 
 type UseFileUploaderProps = {
   fileType?: FILE_TYPE
@@ -20,19 +21,25 @@ type UseFileUploaderProps = {
 export function useFileUploader({ fileType, nodeId }: UseFileUploaderProps) {
   const dispatch = useDispatch()
   const id = React.useRef(nanoid())
+  const workspaceId = useSelector(selectCurrentWorkspaceId)
   const onUploadFile = React.useCallback(
     (formData: FormData, fileName: string) => {
-      dispatch(
-        uploadFile({
-          requestId: id.current,
-          nodeId,
-          fileName,
-          formData,
-          fileType,
-        }),
-      )
+      if (workspaceId) {
+        dispatch(
+          uploadFile({
+            workspaceId,
+            requestId: id.current,
+            nodeId,
+            fileName,
+            formData,
+            fileType,
+          }),
+        )
+      } else {
+        throw new Error('workspaceId is undefined')
+      }
     },
-    [dispatch, fileType, nodeId],
+    [dispatch, workspaceId, fileType, nodeId],
   )
   const uninitialized = useSelector(selectFileUploadIsUninitialized(id.current))
   const filePath = useSelector(selectUploadFilePath(id.current))

--- a/frontend/src/store/slice/FilesTree/FilesTreeAction.ts
+++ b/frontend/src/store/slice/FilesTree/FilesTreeAction.ts
@@ -7,11 +7,14 @@ import {
 
 import { FILES_TREE_SLICE_NAME } from './FilesTreeType'
 
-export const getFilesTree = createAsyncThunk<TreeNodeTypeDTO[], FILE_TREE_TYPE>(
+export const getFilesTree = createAsyncThunk<
+  TreeNodeTypeDTO[],
+  { workspaceId: number; fileType: FILE_TREE_TYPE }
+>(
   `${FILES_TREE_SLICE_NAME}/getFilesTree`,
-  async (fileType, thunkAPI) => {
+  async ({ workspaceId, fileType }, thunkAPI) => {
     try {
-      const response = await getFilesTreeApi(fileType)
+      const response = await getFilesTreeApi(workspaceId, fileType)
       return response
     } catch (e) {
       return thunkAPI.rejectWithValue(e)

--- a/frontend/src/store/slice/FilesTree/FilesTreeSlice.ts
+++ b/frontend/src/store/slice/FilesTree/FilesTreeSlice.ts
@@ -15,7 +15,7 @@ export const filesTreeSlice = createSlice({
   extraReducers: (builder) => {
     builder
       .addCase(getFilesTree.pending, (state, action) => {
-        const fileType = action.meta.arg
+        const { fileType } = action.meta.arg
         state[fileType] = {
           isLoading: true,
           isLatest: false,
@@ -23,10 +23,10 @@ export const filesTreeSlice = createSlice({
         }
       })
       .addCase(getFilesTree.fulfilled, (state, action) => {
-        const fileTreeType = action.meta.arg
-        state[fileTreeType].tree = convertToTreeNodeType(action.payload)
-        state[fileTreeType].isLatest = true
-        state[fileTreeType].isLoading = false
+        const { fileType } = action.meta.arg
+        state[fileType].tree = convertToTreeNodeType(action.payload)
+        state[fileType].isLatest = true
+        state[fileType].isLoading = false
       })
       .addCase(uploadFile.pending, (state, action) => {
         const { fileType } = action.meta.arg

--- a/frontend/src/store/slice/HDF5/HDF5Action.ts
+++ b/frontend/src/store/slice/HDF5/HDF5Action.ts
@@ -3,14 +3,14 @@ import { getHDF5TreeApi, HDF5TreeDTO } from 'api/hdf5/HDF5'
 
 import { HDF5_SLICE_NAME } from './HDF5Type'
 
-export const getHDF5Tree = createAsyncThunk<HDF5TreeDTO[], { path: string }>(
-  `${HDF5_SLICE_NAME}/getHDF5Tree`,
-  async ({ path }, thunkAPI) => {
-    try {
-      const response = await getHDF5TreeApi(path)
-      return response
-    } catch (e) {
-      return thunkAPI.rejectWithValue(e)
-    }
-  },
-)
+export const getHDF5Tree = createAsyncThunk<
+  HDF5TreeDTO[],
+  { path: string; workspaceId: number }
+>(`${HDF5_SLICE_NAME}/getHDF5Tree`, async ({ path, workspaceId }, thunkAPI) => {
+  try {
+    const response = await getHDF5TreeApi(path, workspaceId)
+    return response
+  } catch (e) {
+    return thunkAPI.rejectWithValue(e)
+  }
+})

--- a/studio/app/common/core/snakemake/smk_builder.py
+++ b/studio/app/common/core/snakemake/smk_builder.py
@@ -12,8 +12,14 @@ class RuleBuilder:
         self._hdf5Path = None
         self._path = None
 
-    def set_input(self, input) -> "RuleBuilder":
-        self._input = input
+    def set_input(self, input, workspace_id=None) -> "RuleBuilder":
+        if workspace_id:
+            if isinstance(input, list):
+                self._input = [f"{workspace_id}/{i}" for i in input]
+            else:
+                self._input = f"{workspace_id}/{input}"
+        else:
+            self._input = input
         return self
 
     def set_return_arg(self, return_arg) -> "RuleBuilder":

--- a/studio/app/common/core/snakemake/snakemake_rule.py
+++ b/studio/app/common/core/snakemake/snakemake_rule.py
@@ -33,7 +33,9 @@ class SmkRule:
 
         self.builder = RuleBuilder()
         (
-            self.builder.set_input(self._node.data.path)
+            self.builder.set_input(
+                self._node.data.path, workspace_id=self._workspace_id
+            )
             .set_return_arg(_return_name)
             .set_params(self._node.data.param)
             .set_output(_output_file)

--- a/studio/app/common/routers/files.py
+++ b/studio/app/common/routers/files.py
@@ -28,6 +28,9 @@ class DirTreeGetter:
         else:
             absolute_dirpath = join_filepath([DIRPATH.INPUT_DIR, workspace_id, dirname])
 
+        if not os.path.exists(absolute_dirpath):
+            return nodes
+
         sorted_listdir = sorted(
             os.listdir(absolute_dirpath),
             key=lambda x: (not os.path.isdir(join_filepath([absolute_dirpath, x])), x),

--- a/studio/app/common/routers/files.py
+++ b/studio/app/common/routers/files.py
@@ -18,13 +18,15 @@ router = APIRouter(prefix="/files", tags=["files"])
 
 class DirTreeGetter:
     @classmethod
-    def get_tree(cls, file_types: List[str], dirname: str = None) -> List[TreeNode]:
+    def get_tree(
+        cls, workspace_id, file_types: List[str], dirname: str = None
+    ) -> List[TreeNode]:
         nodes: List[TreeNode] = []
 
         if dirname is None:
-            absolute_dirpath = DIRPATH.INPUT_DIR
+            absolute_dirpath = join_filepath([DIRPATH.INPUT_DIR, workspace_id])
         else:
-            absolute_dirpath = join_filepath([DIRPATH.INPUT_DIR, dirname])
+            absolute_dirpath = join_filepath([DIRPATH.INPUT_DIR, workspace_id, dirname])
 
         sorted_listdir = sorted(
             os.listdir(absolute_dirpath),
@@ -73,21 +75,21 @@ class DirTreeGetter:
         return files_list
 
 
-@router.get("", response_model=List[TreeNode])
-async def get_files(file_type: str = None):
+@router.get("/{workspace_id}", response_model=List[TreeNode])
+async def get_files(workspace_id: str, file_type: str = None):
     if file_type == FILETYPE.IMAGE:
-        return DirTreeGetter.get_tree(ACCEPT_TIFF_EXT)
+        return DirTreeGetter.get_tree(workspace_id, ACCEPT_TIFF_EXT)
     elif file_type == FILETYPE.CSV:
-        return DirTreeGetter.get_tree(ACCEPT_CSV_EXT)
+        return DirTreeGetter.get_tree(workspace_id, ACCEPT_CSV_EXT)
     elif file_type == FILETYPE.HDF5:
-        return DirTreeGetter.get_tree(ACCEPT_HDF5_EXT)
+        return DirTreeGetter.get_tree(workspace_id, ACCEPT_HDF5_EXT)
 
 
-@router.post("/upload/{filename}", response_model=FilePath)
-async def create_file(filename: str, file: UploadFile = File(...)):
-    create_directory(DIRPATH.INPUT_DIR)
+@router.post("/{workspace_id}/upload/{filename}", response_model=FilePath)
+async def create_file(workspace_id: str, filename: str, file: UploadFile = File(...)):
+    create_directory(join_filepath([DIRPATH.INPUT_DIR, workspace_id]))
 
-    filepath = join_filepath([DIRPATH.INPUT_DIR, filename])
+    filepath = join_filepath([DIRPATH.INPUT_DIR, workspace_id, filename])
 
     with open(filepath, "wb") as f:
         shutil.copyfileobj(file.file, f)

--- a/studio/app/common/routers/outputs.py
+++ b/studio/app/common/routers/outputs.py
@@ -117,11 +117,14 @@ async def get_html(filepath: str):
 
 @router.get("/image/{filepath:path}", response_model=OutputData)
 async def get_image(
-    filepath: str, start_index: Optional[int] = 0, end_index: Optional[int] = 1
+    filepath: str,
+    workspace_id: str,
+    start_index: Optional[int] = 0,
+    end_index: Optional[int] = 1,
 ):
     filename, ext = os.path.splitext(os.path.basename(filepath))
     if ext in ACCEPT_TIFF_EXT:
-        filepath = join_filepath([DIRPATH.INPUT_DIR, filepath])
+        filepath = join_filepath([DIRPATH.INPUT_DIR, workspace_id, filepath])
         save_dirpath = join_filepath(
             [
                 os.path.dirname(filepath),
@@ -140,8 +143,8 @@ async def get_image(
 
 
 @router.get("/csv/{filepath:path}", response_model=OutputData)
-async def get_csv(filepath: str):
-    filepath = join_filepath([DIRPATH.INPUT_DIR, filepath])
+async def get_csv(filepath: str, workspace_id: str):
+    filepath = join_filepath([DIRPATH.INPUT_DIR, workspace_id, filepath])
 
     filename, _ = os.path.splitext(os.path.basename(filepath))
     save_dirpath = join_filepath([os.path.dirname(filepath), filename])

--- a/studio/app/optinist/routers/hdf5.py
+++ b/studio/app/optinist/routers/hdf5.py
@@ -70,6 +70,6 @@ class HDF5Getter:
 
 
 @router.get("/hdf5/{file_path:path}", response_model=List[HDF5Node], tags=["outputs"])
-async def get_files(file_path: str):
-    file_path = join_filepath([DIRPATH.INPUT_DIR, file_path])
+async def get_files(file_path: str, workspace_id: str):
+    file_path = join_filepath([DIRPATH.INPUT_DIR, workspace_id, file_path])
     return HDF5Getter.get(file_path)


### PR DESCRIPTION
- #76 の一環

- inputのディレクトリを`input/{workspace_id}/`で分離
- `output/` apiでinputディレクトリの参照にも使用されるもの(`output/csv`, `output/image`)および`/hdf5`のapiについては、クエリパラメータとしてworkspace_idを必須として対応
  - パスパラメータでも良いが、他のouput apiと体裁を整えるためこのような実装としている
