### PR TITLE
Fix sqlalchemy logging duplicated

### DIFF
--- a/studio/app/common/db/config.py
+++ b/studio/app/common/db/config.py
@@ -14,7 +14,6 @@ class DatabaseConfig(BaseSettings):
     MYSQL_PASSWORD: str = Field(default=None, env="MYSQL_PASSWORD")
     MYSQL_DATABASE: str = Field(default=None, env="MYSQL_DATABASE")
     DATABASE_URL: str = Field(default=None)
-    ECHO_SQL: bool = Field(default=None, env="ECHO_SQL")
 
     @validator("DATABASE_URL", pre=True)
     def assemble_db_connection(cls, v: Optional[str], values: Dict[str, Any]) -> Any:

--- a/studio/app/common/db/database.py
+++ b/studio/app/common/db/database.py
@@ -5,12 +5,7 @@ from sqlmodel import create_engine
 
 from .config import DATABASE_CONFIG
 
-engine = create_engine(
-    DATABASE_CONFIG.DATABASE_URL,
-    pool_recycle=360,
-    pool_size=20,
-    echo=DATABASE_CONFIG.ECHO_SQL,
-)
+engine = create_engine(DATABASE_CONFIG.DATABASE_URL, pool_recycle=360, pool_size=20)
 
 SessionLocal = sessionmaker(
     autocommit=False, autoflush=False, expire_on_commit=False, bind=engine

--- a/studio/config/logging.yaml
+++ b/studio/config/logging.yaml
@@ -1,5 +1,5 @@
 version: 1
-disable_existing_loggers: true
+disable_existing_loggers: false
 formatters:
   default:
     (): "uvicorn.logging.DefaultFormatter"
@@ -21,9 +21,11 @@ handlers:
     interval: 1
     backupCount: 365
 loggers:
-  uvicorn:
+  sqlalchemy.engine:
     level: INFO
-    handlers: [console, rotating_file]
+  snakemake:
+    level: INFO
+    handlers: [rotating_file]
     propagate: false
 root:
   level: INFO


### PR DESCRIPTION
I have determined sqlalchemy's `echo=True` option causes this issue. It is not handled by the `logging` module handlers but is written directly to `sys.stdout`.
To work around this issue, remove this option and manually add `sqlalchemy` to the logging configuration.
Snakemake seems to work the same way, so I disabled its `console` handler so it works as expected.