### PR TITLE
add images to expdb

### DIFF
--- a/frontend/src/components/Database/DatabaseCells.tsx
+++ b/frontend/src/components/Database/DatabaseCells.tsx
@@ -30,7 +30,7 @@ type CellProps = {
 
 let timeout: NodeJS.Timeout | undefined = undefined
 
-const columns = (handleOpenDialog: (value: ImageUrls[], expId?: string) => void, user?: boolean) => [
+const columns = (user?: boolean) => [
   {
     field: 'experiment_id',
     headerName: 'Experiment ID',
@@ -97,32 +97,6 @@ const columns = (handleOpenDialog: (value: ImageUrls[], expId?: string) => void,
     width: 160,
     renderCell: (params: { row: DatabaseType }) =>
       params.row.fields?.imaging_depth,
-  },
-  {
-    field: 'cell_image_url',
-    headerName: 'Pixel Image',
-    width: 160,
-    filterable: false,
-    sortable: false,
-    renderCell: (params: { row: DatabaseType }) => {
-      const { cell_image_url } = params.row
-      if (!cell_image_url) return null
-      return (
-        <Box
-          sx={{
-            cursor: 'pointer',
-            display: 'flex',
-          }}
-          onClick={() => handleOpenDialog([cell_image_url])}
-        >
-          <img
-            src={params.row?.cell_image_url?.thumb_url}
-            alt={''}
-            width={'100%'}
-            height={'100%'}
-          />
-      </Box>
-    )}
   },
 ]
 
@@ -319,7 +293,7 @@ const DatabaseCells = ({ user }: CellProps) => {
     )
   }, [dataCells.header?.graph_titles])
 
-  const columnsTable = [...columns(handleOpenDialog, !!user), ...getColumns].filter(
+  const columnsTable = [...columns(!!user), ...getColumns].filter(
     Boolean,
   ) as any
 

--- a/frontend/src/components/Database/DatabaseCells.tsx
+++ b/frontend/src/components/Database/DatabaseCells.tsx
@@ -302,6 +302,7 @@ const DatabaseCells = ({ user }: CellProps) => {
       <DataGrid
         columns={[...columnsTable] as any}
         rows={dataCells?.items || []}
+        rowHeight={128}
         hideFooter={true}
         filterMode={'server'}
         sortingMode={'server'}

--- a/frontend/src/components/Database/DatabaseExperiments.tsx
+++ b/frontend/src/components/Database/DatabaseExperiments.tsx
@@ -615,6 +615,7 @@ const DatabaseExperiments = ({
             : (columnsTable as any)
         }
         rows={dataExperiments?.items || []}
+        rowHeight={128}
         hideFooter={true}
         filterMode={'server'}
         sortingMode={'server'}

--- a/studio/app/common/dataclass/histogram.py
+++ b/studio/app/common/dataclass/histogram.py
@@ -7,6 +7,7 @@ from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.common.core.utils.json_writer import JsonWriter
 from studio.app.common.core.workflow.workflow import OutputPath, OutputType
 from studio.app.common.dataclass.base import BaseData
+from studio.app.common.dataclass.utils import save_thumbnail
 
 
 class HistogramData(BaseData):
@@ -30,4 +31,7 @@ class HistogramData(BaseData):
 
     def save_plot(self, output_dir):
         fig = px.histogram(x=self.data[0], nbins=20)
-        pio.write_image(fig, join_filepath([output_dir, f"{self.file_name}.png"]))
+        plot_file = join_filepath([output_dir, f"{self.file_name}.png"])
+        pio.write_image(fig, plot_file)
+
+        save_thumbnail(plot_file)

--- a/studio/app/common/dataclass/line.py
+++ b/studio/app/common/dataclass/line.py
@@ -6,6 +6,7 @@ from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.common.core.utils.json_writer import JsonWriter
 from studio.app.common.core.workflow.workflow import OutputPath, OutputType
 from studio.app.common.dataclass.base import BaseData
+from studio.app.common.dataclass.utils import save_thumbnail
 
 
 class LineData(BaseData):
@@ -27,6 +28,7 @@ class LineData(BaseData):
     def save_plot(self, output_dir):
         for i in range(len(self.data)):
             fig = px.line(y=self.data[i], x=self.columns)
-            pio.write_image(
-                fig, join_filepath([output_dir, f"{self.file_name}_{i}.png"])
-            )
+            plot_file = join_filepath([output_dir, f"{self.file_name}_{i}.png"])
+            pio.write_image(fig, plot_file)
+
+            save_thumbnail(plot_file)

--- a/studio/app/common/dataclass/pie.py
+++ b/studio/app/common/dataclass/pie.py
@@ -7,6 +7,7 @@ from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.common.core.utils.json_writer import JsonWriter
 from studio.app.common.core.workflow.workflow import OutputPath, OutputType
 from studio.app.common.dataclass.base import BaseData
+from studio.app.common.dataclass.utils import save_thumbnail
 
 
 class PieData(BaseData):
@@ -43,4 +44,7 @@ class PieData(BaseData):
                 )
             ]
         )
-        pio.write_image(fig, join_filepath([output_dir, f"{self.file_name}.png"]))
+        plot_file = join_filepath([output_dir, f"{self.file_name}.png"])
+        pio.write_image(fig, plot_file)
+
+        save_thumbnail(plot_file)

--- a/studio/app/common/dataclass/polar.py
+++ b/studio/app/common/dataclass/polar.py
@@ -6,6 +6,7 @@ from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.common.core.utils.json_writer import JsonWriter
 from studio.app.common.core.workflow.workflow import OutputPath, OutputType
 from studio.app.common.dataclass.base import BaseData
+from studio.app.common.dataclass.utils import save_thumbnail
 
 
 class PolarData(BaseData):
@@ -34,6 +35,8 @@ class PolarData(BaseData):
                 start_angle=0,
                 line_close=True,
             )
-            pio.write_image(
-                fig, join_filepath([output_dir, f"{self.file_name}_{i}.png"])
-            )
+
+            plot_file = join_filepath([output_dir, f"{self.file_name}_{i}.png"])
+            pio.write_image(fig, plot_file)
+
+            save_thumbnail(plot_file)

--- a/studio/app/common/dataclass/utils.py
+++ b/studio/app/common/dataclass/utils.py
@@ -1,6 +1,9 @@
 import copy
 
+import cv2
 import numpy as np
+
+from studio.app.const import THUMBNAIL_HEIGHT
 
 
 def create_images_list(data):
@@ -20,3 +23,12 @@ def create_images_list(data):
         images.append(_img.tolist())
 
     return images
+
+
+def save_thumbnail(plot_file):
+    plot_img = cv2.imread(plot_file)
+    h, w = plot_img.shape[:2]
+    thumb_img = cv2.resize(
+        plot_img, dsize=(int(w * (THUMBNAIL_HEIGHT / h)), THUMBNAIL_HEIGHT)
+    )
+    cv2.imwrite(plot_file.replace(".png", ".thumb.png"), thumb_img)

--- a/studio/app/const.py
+++ b/studio/app/const.py
@@ -20,6 +20,7 @@ NOT_DISPLAY_ARGS_LIST = ["params", "output_dir", "nwbfile", "export_plot"]
 
 DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 
+THUMBNAIL_HEIGHT = 128
 TC_SUFFIX = "timecourse"
 TC_FIELDNAME = "timecourse"
 TS_SUFFIX = "trialstructure"

--- a/studio/app/optinist/core/expdb/batch_runner.py
+++ b/studio/app/optinist/core/expdb/batch_runner.py
@@ -185,7 +185,8 @@ class ExpDbBatchRunner:
 
             expdb_batch.generate_statdata()
             expdb_batch.generate_plots()
-            ncells = expdb_batch.generate_pixelmaps()
+            ncells = expdb_batch.generate_cellmasks()
+            expdb_batch.generate_pixelmaps()
 
             exp = create_experiment(
                 db,

--- a/studio/app/optinist/routers/expdb.py
+++ b/studio/app/optinist/routers/expdb.py
@@ -107,7 +107,6 @@ def get_experiment_urls(source, exp_dir, params=None):
     return [
         ImageInfo(
             url=f"{exp_dir}/{v['dir']}/{k}.png",
-            thumb_url=f"{exp_dir}/{v['dir']}/{k}.png",
             params=params,
         )
         for k, v in source.items()
@@ -116,14 +115,14 @@ def get_experiment_urls(source, exp_dir, params=None):
 
 def get_pixelmap_urls(exp_dir, params=None):
     dirs = exp_dir.split("/")
-    pixelmaps = glob(
-        f"{DIRPATH.PUBLIC_EXPDB_DIR}/{dirs[-2]}/{dirs[-1]}/pixelmaps/*.png"
+    pub_dir = f"{DIRPATH.PUBLIC_EXPDB_DIR}/{dirs[-2]}/{dirs[-1]}/pixelmaps/"
+    pixelmaps = sorted(
+        list(set(glob(f"{pub_dir}/*.png")) - set(glob(f"{pub_dir}/*.thumb.png")))
     )
 
     return [
         ImageInfo(
             url=f"{exp_dir}/pixelmaps/{os.path.basename(k)}",
-            thumb_url=f"{exp_dir}/pixelmaps/{os.path.basename(k)}",
             params=params,
         )
         for k in pixelmaps
@@ -141,7 +140,6 @@ def get_cell_urls(source, exp_dir, index: int, params=None):
     return [
         ImageInfo(
             url=f"{exp_dir}/{v['dir']}/{k}_{index}.png",
-            thumb_url=f"{exp_dir}/{v['dir']}/{k}_{index}.png",
             params=params,
         )
         for k, v in source.items()

--- a/studio/app/optinist/schemas/expdb/cell.py
+++ b/studio/app/optinist/schemas/expdb/cell.py
@@ -14,7 +14,6 @@ class ExpDbCell(BaseModel):
     experiment_id: str = None
     publish_status: Optional[int] = Field(description="0: private, 1: public")
     fields: ExpDbExperimentFields = None
-    cell_image_url: ImageInfo = None
     graph_urls: List[ImageInfo] = None
     created_at: datetime = None
     updated_at: datetime = None

--- a/studio/app/optinist/schemas/expdb/experiment.py
+++ b/studio/app/optinist/schemas/expdb/experiment.py
@@ -38,8 +38,13 @@ class ExpDbExperimentHeader(BaseModel):
 
 class ImageInfo(BaseModel):
     url: str
-    thumb_url: str
+    thumb_url: Optional[str]
     params: Optional[dict]
+
+    def __init__(self, url, params=None, thumb_url=None):
+        super().__init__(url=url, thumb_url=thumb_url, params=params)
+        if thumb_url is None:
+            self.thumb_url = url.replace(".png", ".thumb.png")
 
 
 class ExpDbExperiment(BaseModel):


### PR DESCRIPTION
- ExperimentテーブルのPixel Image欄に表示する画像を修正
  - Before: cellmask
  - After: raw dataの`*_hc.tif`, `*_hc_{NUMBER}.tif`をpngに変換した画像
    - こちらの対象抽出ロジックが2パターンになっているため、末尾_hc.tifに統一や、ディレクトリを分ける、などの調整ができると望ましい
    - hcがない場合は画像を生成していないため、その条件で良いか要検討
- サムネイル画像の生成処理を追加
  - サムネイル画像は高さ128pxを目安に生成
- テーブルレイアウトの修正
  - 不要なカラムの削除
  - 行高さをサムネイルと一致するように調整

## 備考
- 対象データの抽出ロジックがやや煩雑なため、識別子、ディレクトリなどの調整を検討が必要かもしれない
  - _hc.tifと_hc_{NUMBER}.tifの混在
  - 