### PR TITLE
save start time for each process

### DIFF
--- a/studio/app/optinist/core/expdb/batch_runner.py
+++ b/studio/app/optinist/core/expdb/batch_runner.py
@@ -181,6 +181,7 @@ class ExpDbBatchRunner:
             self.logger_.info(
                 "start process dataset: [exp_id: %s][flag_file: %s]", exp_id, flag_file
             )
+            self.start_time = datetime.datetime.now()
 
             error: Exception = None
 


### PR DESCRIPTION
procファイルのstart_timeを修正
- before: バッチ処理自体の開始時刻
- after: 対象のexperimentの処理開始時刻