### PR TITLE
add node version restriction

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,9 @@
 {
   "name": "optinist",
   "version": "0.1.0",
+  "engines": {
+    "node": ">=16.0.0 <19.0.0"
+  },
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.7.1",


### PR DESCRIPTION
利用可能なnodeのバージョンを16~18に制限
なお、bareboneの内容を11月中旬に取り込む際に20に更新予定
