### PR TITLE
set channel priority for non-root user

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -43,6 +43,7 @@ services:
       TZ: Asia/Tokyo
       OPTINIST_DIR: /tmp
       POETRY_VIRTUALENVS_CREATE: false
+      CONDA_CHANNEL_PRIORITY: strict
     depends_on:
       - db
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       TZ: Asia/Tokyo
       OPTINIST_DIR: /app/studio_data
       POETRY_VIRTUALENVS_CREATE: false
+      CONDA_CHANNEL_PRIORITY: strict
     depends_on:
       - db
     restart: always


### PR DESCRIPTION
Dockerfile内で以下のコマンドでchannel_priorityを設定しているが、こちらはrootユーザーのみに適用されている。
```
conda config --set channel_priority strict && \
```

当リポジトリでは実行ユーザーが`optinist`になっているので、環境変数でchannel_priorityを割り当てるように変更。