### PR TITLE
Feature/expdb selct clear wfid

### DIFF
--- a/frontend/src/components/Workspace/FlowChart/FlowChartNode/ExpDbNode.tsx
+++ b/frontend/src/components/Workspace/FlowChart/FlowChartNode/ExpDbNode.tsx
@@ -27,6 +27,7 @@ import {
   selectExpDbInputNodeSelectedFilePath,
   selectInputNodeDefined,
 } from "store/slice/InputNode/InputNodeSelectors"
+import { selectPipelineLatestUid } from "store/slice/Pipeline/PipelineSelectors"
 import { selectCurrentUser } from "store/slice/User/UserSelector"
 import { RootState } from "store/store"
 
@@ -112,6 +113,7 @@ export const ExpDbSelectDialog = memo(function ExpDbSelectDialog({
   setOpen,
 }: ExpDbSelectDialogProps) {
   const { onOpenClearWorkflowIdDialog } = useContext(DialogContext)
+  const currentPipelineUid = useSelector(selectPipelineLatestUid)
   const currentExperimentId = useSelector(experimentIdSelector(nodeId))
   const user = useSelector(selectCurrentUser)
   const [experimentId, setExperimentId] = useState<string | undefined>(
@@ -133,7 +135,7 @@ export const ExpDbSelectDialog = memo(function ExpDbSelectDialog({
 
   const onClickOk = () => {
     try {
-      if (currentExperimentId != null && currentExperimentId !== experimentId) {
+      if (currentPipelineUid && currentExperimentId !== experimentId) {
         onOpenClearWorkflowIdDialog({
           open: true,
           handleOk: () => {

--- a/frontend/src/components/Workspace/FlowChart/FlowChartNode/MicroscopeFileNode.tsx
+++ b/frontend/src/components/Workspace/FlowChart/FlowChartNode/MicroscopeFileNode.tsx
@@ -74,7 +74,12 @@ const ExpDbSelect = memo(function ExpDbSelect({ nodeId }: { nodeId: string }) {
       <Button size="small" variant="outlined" onClick={() => setOpen(true)}>
         Select
       </Button>
-      <ExpDbSelectDialog nodeId={nodeId} open={open} setOpen={setOpen} />
+      <ExpDbSelectDialog
+        nodeId={nodeId}
+        open={open}
+        setOpen={setOpen}
+        experimentIdSelector={selectMicroscopeInputNodeSelectedFilePath}
+      />
       <Typography>
         {experimentId
           ? `Selected experiment id: ${experimentId}`


### PR DESCRIPTION
以下のコメントへの対応

https://github.com/arayabrain/optinist-for-server/pull/262#discussion_r1542253630

当リポジトリ固有のデータベースからのファイル選択において、実行済のワークフローの場合はinput nodeの選択experiment変更時にダイアログ表示とOK選択時のRUN ALL強制を適用。