### PR TITLE
save ome meta data into nwb

### DIFF
--- a/studio/app/common/core/rules/runner.py
+++ b/studio/app/common/core/rules/runner.py
@@ -48,6 +48,9 @@ class Runner:
                 input_info,
             )
 
+            if "input" in output_info.get("nwbfile", {}):
+                nwbfile["input"] = output_info["nwbfile"]["input"]
+
             # nwbfileの設定
             output_info["nwbfile"] = cls.save_func_nwb(
                 f"{__rule.output.split('.')[0]}.nwb",

--- a/studio/app/optinist/core/nwb/device_metadata.py
+++ b/studio/app/optinist/core/nwb/device_metadata.py
@@ -1,0 +1,69 @@
+from pynwb import get_class, load_namespaces
+from pynwb.spec import NWBDatasetSpec, NWBGroupSpec, NWBNamespaceBuilder
+
+name = "device_metadata"
+ns_path = f"{name}.namespace.yaml"
+ext_source = f"{name}.extensions.yaml"
+
+img_ext = NWBGroupSpec(
+    doc="Imaging metadata",
+    name="Image",
+    datasets=[
+        NWBDatasetSpec(doc="Name", name="Name", dtype="text", quantity="?"),
+        NWBDatasetSpec(
+            doc="AcquisitionDate", name="AcquisitionDate", dtype="text", quantity="?"
+        ),
+        NWBDatasetSpec(
+            doc="ImagingRate", name="ImagingRate", dtype="float", quantity="?"
+        ),
+    ],
+    neurodata_type_def="ImagingMetaData",
+    neurodata_type_inc="NWBContainer",
+    quantity="?",
+)
+pixels_ext = NWBGroupSpec(
+    doc="Pixels metadata",
+    name="Pixels",
+    datasets=[
+        NWBDatasetSpec(doc="SizeC", name="SizeC", dtype="int", quantity="?"),
+        NWBDatasetSpec(doc="SizeT", name="SizeT", dtype="int", quantity="?"),
+        NWBDatasetSpec(doc="SizeX", name="SizeX", dtype="int", quantity="?"),
+        NWBDatasetSpec(doc="SizeY", name="SizeY", dtype="int", quantity="?"),
+        NWBDatasetSpec(doc="SizeZ", name="SizeZ", dtype="int", quantity="?"),
+        NWBDatasetSpec(
+            doc="SignificantBits", name="SignificantBits", dtype="int", quantity="?"
+        ),
+        NWBDatasetSpec(doc="Type", name="Type", dtype="text", quantity="?"),
+    ],
+    neurodata_type_def="PixelsMetaData",
+    neurodata_type_inc="NWBContainer",
+    quantity="?",
+)
+
+objective_ext = NWBGroupSpec(
+    doc="Objective metadata",
+    name="Objective",
+    datasets=[
+        NWBDatasetSpec(doc="Model", name="Model", dtype="text", quantity="?"),
+    ],
+    neurodata_type_def="ObjectiveMetaData",
+    neurodata_type_inc="NWBContainer",
+    quantity="?",
+)
+
+device_ext = NWBGroupSpec(
+    doc="Device metadata",
+    groups=[img_ext, pixels_ext, objective_ext],
+    neurodata_type_def="DeviceMetaData",
+    neurodata_type_inc="Device",
+)
+
+ns_builder = NWBNamespaceBuilder(f"{name} extensions", name, version="0.1.0")
+ns_builder.add_spec(ext_source, device_ext)
+ns_builder.export(ns_path)
+load_namespaces(ns_path)
+
+ImagingMetaData = get_class("ImagingMetaData", name)
+PixelsMetaData = get_class("PixelsMetaData", name)
+ObjectiveMetaData = get_class("ObjectiveMetaData", name)
+DeviceMetaData = get_class("DeviceMetaData", name)

--- a/studio/app/optinist/core/nwb/device_metadata.py
+++ b/studio/app/optinist/core/nwb/device_metadata.py
@@ -56,6 +56,15 @@ objective_ext = NWBGroupSpec(
     quantity="?",
 )
 
+ome_ext = NWBGroupSpec(
+    doc="OME metadata",
+    name="MicroscopeOMEMetaData",
+    groups=[img_ext, pixels_ext, objective_ext],
+    neurodata_type_def="MicroscopeOMEMetaData",
+    neurodata_type_inc="NWBContainer",
+    quantity="?",
+)
+
 LAB_SPECIFIC_TYPES = {
     # Common
     "uiWidth": "numeric",
@@ -106,21 +115,21 @@ LAB_SPECIFIC_TYPES = {
     "CommentByUser": "text",
 }
 
-lab_specific_ext = NWBGroupSpec(
+lab_ext = NWBGroupSpec(
     doc="Lab specific microscope metadata",
-    name="LabMicroscopeMetaData",
+    name="MicroscopeLabMetaData",
     datasets=[
         NWBDatasetSpec(doc=k, name=k, dtype=v, quantity="?")
         for k, v in LAB_SPECIFIC_TYPES.items()
     ],
-    neurodata_type_def="LabMicroscopeMetaData",
+    neurodata_type_def="MicroscopeLabMetaData",
     neurodata_type_inc="NWBContainer",
     quantity="?",
 )
 
 device_ext = NWBGroupSpec(
     doc="Device metadata",
-    groups=[img_ext, pixels_ext, objective_ext, lab_specific_ext],
+    groups=[ome_ext, lab_ext],
     neurodata_type_def="DeviceMetaData",
     neurodata_type_inc="Device",
 )
@@ -133,5 +142,6 @@ load_namespaces(ns_path)
 ImagingMetaData = get_class("ImagingMetaData", name)
 PixelsMetaData = get_class("PixelsMetaData", name)
 ObjectiveMetaData = get_class("ObjectiveMetaData", name)
-LabMicroscopeMetaData = get_class("LabMicroscopeMetaData", name)
+MicroscopeOMEMetaData = get_class("MicroscopeOMEMetaData", name)
+MicroscopeLabMetaData = get_class("MicroscopeLabMetaData", name)
 DeviceMetaData = get_class("DeviceMetaData", name)

--- a/studio/app/optinist/core/nwb/device_metadata.py
+++ b/studio/app/optinist/core/nwb/device_metadata.py
@@ -5,35 +5,40 @@ name = "device_metadata"
 ns_path = f"{name}.namespace.yaml"
 ext_source = f"{name}.extensions.yaml"
 
+IMAGE_TYPES = {
+    "Name": "text",
+    "AcquisitionDate": "text",
+    "ImagingRate": "numeric",
+}
+
 img_ext = NWBGroupSpec(
     doc="Imaging metadata",
     name="Image",
     datasets=[
-        NWBDatasetSpec(doc="Name", name="Name", dtype="text", quantity="?"),
-        NWBDatasetSpec(
-            doc="AcquisitionDate", name="AcquisitionDate", dtype="text", quantity="?"
-        ),
-        NWBDatasetSpec(
-            doc="ImagingRate", name="ImagingRate", dtype="float", quantity="?"
-        ),
+        NWBDatasetSpec(doc=k, name=k, dtype=v, quantity="?")
+        for k, v in IMAGE_TYPES.items()
     ],
     neurodata_type_def="ImagingMetaData",
     neurodata_type_inc="NWBContainer",
     quantity="?",
 )
+
+PIXEL_TYPES = {
+    "SizeC": "numeric",
+    "SizeT": "numeric",
+    "SizeX": "numeric",
+    "SizeY": "numeric",
+    "SizeZ": "numeric",
+    "SignificantBits": "numeric",
+    "Type": "text",
+}
+
 pixels_ext = NWBGroupSpec(
     doc="Pixels metadata",
     name="Pixels",
     datasets=[
-        NWBDatasetSpec(doc="SizeC", name="SizeC", dtype="int", quantity="?"),
-        NWBDatasetSpec(doc="SizeT", name="SizeT", dtype="int", quantity="?"),
-        NWBDatasetSpec(doc="SizeX", name="SizeX", dtype="int", quantity="?"),
-        NWBDatasetSpec(doc="SizeY", name="SizeY", dtype="int", quantity="?"),
-        NWBDatasetSpec(doc="SizeZ", name="SizeZ", dtype="int", quantity="?"),
-        NWBDatasetSpec(
-            doc="SignificantBits", name="SignificantBits", dtype="int", quantity="?"
-        ),
-        NWBDatasetSpec(doc="Type", name="Type", dtype="text", quantity="?"),
+        NWBDatasetSpec(doc=k, name=k, dtype=v, quantity="?")
+        for k, v in PIXEL_TYPES.items()
     ],
     neurodata_type_def="PixelsMetaData",
     neurodata_type_inc="NWBContainer",
@@ -51,9 +56,71 @@ objective_ext = NWBGroupSpec(
     quantity="?",
 )
 
+LAB_SPECIFIC_TYPES = {
+    # Common
+    "uiWidth": "numeric",
+    "uiHeight": "numeric",
+    "Loops": "numeric",
+    "ZSlicenum": "numeric",
+    "ZInterval": "numeric",
+    "ObjectiveName": "text",
+    "Date": "text",
+    # ND2 specific
+    "uiWidthBytes": "numeric",
+    "uiColor": "numeric",
+    "uiBpcInMemory": "numeric",
+    "uiBpcSignificant": "numeric",
+    "uiSequenceCount": "numeric",
+    "uiTileWidth": "numeric",
+    "uiTileHeight": "numeric",
+    "uiCompression": "numeric",
+    "uiQuality": "numeric",
+    "Type": "text",
+    "dTimeStart": "numeric",
+    "MicroPerPixel": "numeric",
+    "PixelAspect": "numeric",
+    "dObjectiveMag": "numeric",
+    "dObjectiveNA": "numeric",
+    "dZoom": "numeric",
+    "wszDescription": "text",
+    "wszCapturing": "text",
+    # OIR specific
+    "nChannel": "numeric",
+    "PixelLengthX": "numeric",
+    "PixelLengthY": "numeric",
+    "TInterval": "numeric",
+    "ZStart": "numeric",
+    "ZEnd": "numeric",
+    "ObjectiveMag": "numeric",
+    "ObjectiveNA": "numeric",
+    "ReflectiveIndex": "numeric",
+    "Immersion": "text",
+    "NumberOfGroup": "numeric",
+    "NumberOfLevel": "numeric",
+    "NumberOfArea": "numeric",
+    "ByteDepthCh0": "numeric",
+    "SystemName": "text",
+    "SystemVersion": "text",
+    "DeviceName": "text",
+    "UserName": "text",
+    "CommentByUser": "text",
+}
+
+lab_specific_ext = NWBGroupSpec(
+    doc="Lab specific microscope metadata",
+    name="LabMicroscopeMetaData",
+    datasets=[
+        NWBDatasetSpec(doc=k, name=k, dtype=v, quantity="?")
+        for k, v in LAB_SPECIFIC_TYPES.items()
+    ],
+    neurodata_type_def="LabMicroscopeMetaData",
+    neurodata_type_inc="NWBContainer",
+    quantity="?",
+)
+
 device_ext = NWBGroupSpec(
     doc="Device metadata",
-    groups=[img_ext, pixels_ext, objective_ext],
+    groups=[img_ext, pixels_ext, objective_ext, lab_specific_ext],
     neurodata_type_def="DeviceMetaData",
     neurodata_type_inc="Device",
 )
@@ -66,4 +133,5 @@ load_namespaces(ns_path)
 ImagingMetaData = get_class("ImagingMetaData", name)
 PixelsMetaData = get_class("PixelsMetaData", name)
 ObjectiveMetaData = get_class("ObjectiveMetaData", name)
+LabMicroscopeMetaData = get_class("LabMicroscopeMetaData", name)
 DeviceMetaData = get_class("DeviceMetaData", name)

--- a/studio/app/optinist/core/nwb/nwb_creater.py
+++ b/studio/app/optinist/core/nwb/nwb_creater.py
@@ -19,7 +19,8 @@ from pynwb.ophys import (
 from studio.app.optinist.core.nwb.device_metadata import (
     DeviceMetaData,
     ImagingMetaData,
-    LabMicroscopeMetaData,
+    MicroscopeLabMetaData,
+    MicroscopeOMEMetaData,
     ObjectiveMetaData,
     PixelsMetaData,
 )
@@ -67,15 +68,19 @@ class NWBCreater:
         objective_mata = device_metadata.get("Objective")
         lab_specific_meta = config["device"].get("lab_specific_metadata")
         device = DeviceMetaData(
-            Image=None if image_meta is None else ImagingMetaData(**image_meta),
-            Pixels=None if pixels_meta is None else PixelsMetaData(**pixels_meta),
-            Objective=(
-                None if objective_mata is None else ObjectiveMetaData(**objective_mata)
+            MicroscopeOMEMetaData=MicroscopeOMEMetaData(
+                Image=None if image_meta is None else ImagingMetaData(**image_meta),
+                Pixels=None if pixels_meta is None else PixelsMetaData(**pixels_meta),
+                Objective=(
+                    None
+                    if objective_mata is None
+                    else ObjectiveMetaData(**objective_mata)
+                ),
             ),
-            LabMicroscopeMetaData=(
+            MicroscopeLabMetaData=(
                 None
                 if lab_specific_meta is None
-                else LabMicroscopeMetaData(**lab_specific_meta)
+                else MicroscopeLabMetaData(**lab_specific_meta)
             ),
             name=config["device"]["name"],
             description=config["device"]["description"],

--- a/studio/app/optinist/core/nwb/nwb_creater.py
+++ b/studio/app/optinist/core/nwb/nwb_creater.py
@@ -16,6 +16,12 @@ from pynwb.ophys import (
     TwoPhotonSeries,
 )
 
+from studio.app.optinist.core.nwb.device_metadata import (
+    DeviceMetaData,
+    ImagingMetaData,
+    ObjectiveMetaData,
+    PixelsMetaData,
+)
 from studio.app.optinist.core.nwb.lab_metadata import (
     LAB_SPECIFIC_KEY,
     LAB_SPECIFIC_TYPES,
@@ -54,11 +60,16 @@ class NWBCreater:
         )
 
         # 顕微鏡情報を登録
-        device = nwbfile.create_device(
+        device_metadata = config["device"].get("metadata", {})
+        device = DeviceMetaData(
+            Image=ImagingMetaData(**device_metadata.get("Image", {})),
+            Pixels=PixelsMetaData(**device_metadata.get("Pixels", {})),
+            Objective=ObjectiveMetaData(**device_metadata.get("Objective", {})),
             name=config["device"]["name"],
             description=config["device"]["description"],
             manufacturer=config["device"]["manufacturer"],
         )
+        nwbfile.add_device(device)
 
         # 光チャネルを登録
         optical_channel = OpticalChannel(
@@ -394,7 +405,10 @@ class NWBCreater:
 
         devices = []
         for key in nwbfile.devices.keys():
-            device = new_nwbfile.create_device(
+            device = DeviceMetaData(
+                Image=nwbfile.devices[key].Image,
+                Pixels=nwbfile.devices[key].Pixels,
+                Objective=nwbfile.devices[key].Objective,
                 name=key,
                 description=nwbfile.devices[key].description,
                 manufacturer=nwbfile.devices[key].manufacturer,

--- a/studio/app/optinist/core/nwb/nwb_creater.py
+++ b/studio/app/optinist/core/nwb/nwb_creater.py
@@ -19,6 +19,7 @@ from pynwb.ophys import (
 from studio.app.optinist.core.nwb.device_metadata import (
     DeviceMetaData,
     ImagingMetaData,
+    LabMicroscopeMetaData,
     ObjectiveMetaData,
     PixelsMetaData,
 )
@@ -61,10 +62,21 @@ class NWBCreater:
 
         # 顕微鏡情報を登録
         device_metadata = config["device"].get("metadata", {})
+        image_meta = device_metadata.get("Image")
+        pixels_meta = device_metadata.get("Pixels")
+        objective_mata = device_metadata.get("Objective")
+        lab_specific_meta = config["device"].get("lab_specific_metadata")
         device = DeviceMetaData(
-            Image=ImagingMetaData(**device_metadata.get("Image", {})),
-            Pixels=PixelsMetaData(**device_metadata.get("Pixels", {})),
-            Objective=ObjectiveMetaData(**device_metadata.get("Objective", {})),
+            Image=None if image_meta is None else ImagingMetaData(**image_meta),
+            Pixels=None if pixels_meta is None else PixelsMetaData(**pixels_meta),
+            Objective=(
+                None if objective_mata is None else ObjectiveMetaData(**objective_mata)
+            ),
+            LabMicroscopeMetaData=(
+                None
+                if lab_specific_meta is None
+                else LabMicroscopeMetaData(**lab_specific_meta)
+            ),
             name=config["device"]["name"],
             description=config["device"]["description"],
             manufacturer=config["device"]["manufacturer"],

--- a/studio/app/optinist/wrappers/expdb/preprocessing.py
+++ b/studio/app/optinist/wrappers/expdb/preprocessing.py
@@ -28,6 +28,8 @@ def preprocessing(
     nwbfile = kwargs.get("nwbfile", {})
     nwbfile["imaging_plane"]["imaging_rate"] = ome_meta.imaging_rate
     nwbfile["device"]["metadata"] = ome_meta.get_ome_values()
+    if reader.lab_specific_metadata is not None:
+        nwbfile["device"]["lab_specific_metadata"] = reader.lab_specific_metadata
     info = {"nwbfile": {"input": nwbfile}}
 
     raw_stack = reader.get_image_stacks()  # (ch, t, y, x) or (ch, t, z, y, x)

--- a/studio/app/optinist/wrappers/expdb/preprocessing.py
+++ b/studio/app/optinist/wrappers/expdb/preprocessing.py
@@ -24,6 +24,12 @@ def preprocessing(
     reader = microscope.reader
     exp_id = os.path.basename(os.path.dirname(microscope.path))
     ome_meta = reader.ome_metadata
+
+    nwbfile = kwargs.get("nwbfile", {})
+    nwbfile["imaging_plane"]["imaging_rate"] = ome_meta.imaging_rate
+    nwbfile["device"]["metadata"] = ome_meta.get_ome_values()
+    info = {"nwbfile": {"input": nwbfile}}
+
     raw_stack = reader.get_image_stacks()  # (ch, t, y, x) or (ch, t, z, y, x)
     microscope.set_data(raw_stack)
     is_timeseries = ome_meta.size_t > 1
@@ -37,8 +43,6 @@ def preprocessing(
             stack = raw_stack[ch].transpose(2, 3, 1, 0)  # (y, x, z, t)
         else:
             stack = raw_stack[ch].transpose(1, 2, 0)  # (y, x, t)
-
-        info = {}
 
         if is_timeseries:
             period = params["period"]


### PR DESCRIPTION
NWB Fileに顕微鏡のOMEメタデータを格納する機能を実装。

`general/devices`セクションの`Device`クラスを
[NWBの標準の`Device`クラス](https://pynwb.readthedocs.io/en/stable/pynwb.device.html#pynwb.device.Device)から拡張している。

<img width="273" alt="Screenshot 2024-04-01 at 16 42 26" src="https://github.com/arayabrain/optinist-for-server/assets/42664619/46db4520-f7b7-4865-a3c3-41b5fa5ec069">

バッチ処理、および顕微鏡データを入力とするワークフローでこれらの値がNWBへ保存される。