### PR TITLE
Feature/refactor microscope code

### DIFF
--- a/studio/app/optinist/dataclass/microscope.py
+++ b/studio/app/optinist/dataclass/microscope.py
@@ -1,10 +1,4 @@
-import os
-
 from studio.app.common.dataclass.base import BaseData
-from studio.app.optinist.microscopes.IsxdReader import IsxdReader
-from studio.app.optinist.microscopes.ND2Reader import ND2Reader
-from studio.app.optinist.microscopes.OIRReader import OIRReader
-from studio.app.optinist.microscopes.ThorlabsReader import ThorlabsReader
 
 
 class MicroscopeData(BaseData):
@@ -12,52 +6,12 @@ class MicroscopeData(BaseData):
         super().__init__(file_name)
         self.path = path
         self.json_path = None
-        self.__reader = None
         self.__data = None
-
-    def initialize(self):
-        """
-        Since ctypes-using objects cannot be pikle-ized (in this case, reader),
-          the initialization process is separated from __init__().
-        """
-        if self.__reader is not None:
-            return self.__reader
-
-        ext = os.path.splitext(self.path)[1]
-        if ext == ".nd2":
-            reader = ND2Reader()
-        elif ext == ".oir":
-            assert OIRReader.is_available(), "OIRReader is not available."
-            reader = OIRReader()
-        elif ext == ".isxd":
-            reader = IsxdReader()
-        elif ext == ".thor.zip":
-            self.path = os.path.dirname(self.path)
-            reader = ThorlabsReader()
-        else:
-            raise Exception(f"Unsupported file type: {ext}")
-
-        reader.load(self.path)
-        self.__reader = reader
-
-        return reader
-
-    def load_data(self):
-        self.__data = self.__reader.get_image_stacks()
-        return self.__data
-
-    def release(self):
-        """
-        Since ctypes use objects cannot be pikle-ized (in this case, reader),
-          an explicit release process is provided.
-        """
-        self.__reader = None
-        self.__data = None
-
-    @property
-    def reader(self):
-        return self.__reader
 
     @property
     def data(self):
         return self.__data
+
+    @data.setter
+    def data(self, data):
+        self.__data = data

--- a/studio/app/optinist/microscopes/MicroscopeDataReaderUtils.py
+++ b/studio/app/optinist/microscopes/MicroscopeDataReaderUtils.py
@@ -1,0 +1,36 @@
+import os
+
+from studio.app.optinist.microscopes.IsxdReader import IsxdReader
+from studio.app.optinist.microscopes.ND2Reader import ND2Reader
+from studio.app.optinist.microscopes.OIRReader import OIRReader
+from studio.app.optinist.microscopes.ThorlabsReader import ThorlabsReader
+
+
+class MicroscopeDataReaderUtils:
+    """Microscope data reader utilities class"""
+
+    @staticmethod
+    def get_reader(data_file_path: str):
+        """
+        Automatic generation of Reader from file type information
+        """
+        ext = os.path.splitext(data_file_path)[1]
+
+        if ext == ".nd2":
+            assert ND2Reader.is_available(), "ND2Reader is not available."
+            reader = ND2Reader()
+        elif ext == ".oir":
+            assert OIRReader.is_available(), "OIRReader is not available."
+            reader = OIRReader()
+        elif ext == ".isxd":
+            assert IsxdReader.is_available(), "IsxdReader is not available."
+            reader = IsxdReader()
+        elif ext == ".thor.zip":
+            assert ThorlabsReader.is_available(), "ThorlabsReader is not available."
+            reader = ThorlabsReader()
+        else:
+            raise Exception(f"Unsupported file type: {ext}")
+
+        reader.load(data_file_path)
+
+        return reader

--- a/studio/app/optinist/wrappers/expdb/preprocessing.py
+++ b/studio/app/optinist/wrappers/expdb/preprocessing.py
@@ -21,11 +21,10 @@ def preprocessing(
         params_flatten.update(segment)
     params = params_flatten
 
-    reader = microscope.reader
     exp_id = os.path.basename(os.path.dirname(microscope.path))
-    ome_meta = reader.ome_metadata
-    raw_stack = reader.get_image_stacks()  # (ch, t, y, x) or (ch, t, z, y, x)
-    microscope.set_data(raw_stack)
+    microscope.initialize()
+    ome_meta = microscope.reader.ome_metadata
+    raw_stack = microscope.load_data()  # (ch, t, y, x) or (ch, t, z, y, x)
     is_timeseries = ome_meta.size_t > 1
 
     # set common params to variables
@@ -113,5 +112,8 @@ def preprocessing(
                 output_dir=output_dir,
                 file_name=f"{exp_id}_corrected_stack_ch{ch + 1}",
             )
+
+        # Explicitly release MicroscopeData
+        microscope.release()
 
         return info

--- a/studio/app/optinist/wrappers/expdb/preprocessing.py
+++ b/studio/app/optinist/wrappers/expdb/preprocessing.py
@@ -4,6 +4,9 @@ import numpy as np
 
 from studio.app.common.dataclass.image import ImageData
 from studio.app.optinist.dataclass.microscope import MicroscopeData
+from studio.app.optinist.microscopes.MicroscopeDataReaderUtils import (
+    MicroscopeDataReaderUtils,
+)
 from studio.app.optinist.wrappers.expdb.stack_average import stack_average
 from studio.app.optinist.wrappers.expdb.stack_phase_correct import stack_phase_correct
 from studio.app.optinist.wrappers.expdb.stack_register import (
@@ -22,9 +25,10 @@ def preprocessing(
     params = params_flatten
 
     exp_id = os.path.basename(os.path.dirname(microscope.path))
-    microscope.initialize()
-    ome_meta = microscope.reader.ome_metadata
-    raw_stack = microscope.load_data()  # (ch, t, y, x) or (ch, t, z, y, x)
+    reader = MicroscopeDataReaderUtils.get_reader(microscope.path)
+    ome_meta = reader.ome_metadata
+    raw_stack = reader.get_image_stacks()  # (ch, t, y, x) or (ch, t, z, y, x)
+    microscope.data = raw_stack
     is_timeseries = ome_meta.size_t > 1
 
     # set common params to variables
@@ -112,8 +116,5 @@ def preprocessing(
                 output_dir=output_dir,
                 file_name=f"{exp_id}_corrected_stack_ch{ch + 1}",
             )
-
-        # Explicitly release MicroscopeData
-        microscope.release()
 
         return info


### PR DESCRIPTION
### 更新内容

- reader の初期化コードを、Utility class (MicroscopeDataReaderUtils) へ移動
- 伴い、MicroscopeData 内から、reader 操作に関するコードを削除
  - ※pikleを利用する関係で、MicroscopeData 内には readerインスタンス（ctype利用オブジェクト）を格納不可である点を考慮
