### PR TITLE
fix MicroscopeDataReaderUtils.get_reader

### DIFF
--- a/studio/app/optinist/microscopes/MicroscopeDataReaderUtils.py
+++ b/studio/app/optinist/microscopes/MicroscopeDataReaderUtils.py
@@ -1,9 +1,13 @@
 import os
+import re
+from enum import Enum
 
-from studio.app.optinist.microscopes.IsxdReader import IsxdReader
-from studio.app.optinist.microscopes.ND2Reader import ND2Reader
-from studio.app.optinist.microscopes.OIRReader import OIRReader
-from studio.app.optinist.microscopes.ThorlabsReader import ThorlabsReader
+
+class MicroscopeDataFileExt(Enum):
+    ND2_FILE_EXT = ".*\\.nd2$"
+    OIR_FILE_EXT = ".*\\.oir$"
+    ISX_FILE_EXT = ".*\\.isx$"
+    THOR_FILE_EXT = ".*\\.thor.zip$"
 
 
 class MicroscopeDataReaderUtils:
@@ -14,22 +18,26 @@ class MicroscopeDataReaderUtils:
         """
         Automatic generation of Reader from file type information
         """
-        ext = os.path.splitext(data_file_path)[1]
+        from studio.app.optinist.microscopes.IsxdReader import IsxdReader
+        from studio.app.optinist.microscopes.ND2Reader import ND2Reader
+        from studio.app.optinist.microscopes.OIRReader import OIRReader
+        from studio.app.optinist.microscopes.ThorlabsReader import ThorlabsReader
 
-        if ext == ".nd2":
+        if re.match(MicroscopeDataFileExt.ND2_FILE_EXT.value, data_file_path):
             assert ND2Reader.is_available(), "ND2Reader is not available."
             reader = ND2Reader()
-        elif ext == ".oir":
+        elif re.match(MicroscopeDataFileExt.OIR_FILE_EXT.value, data_file_path):
             assert OIRReader.is_available(), "OIRReader is not available."
             reader = OIRReader()
-        elif ext == ".isxd":
+        elif re.match(MicroscopeDataFileExt.ISX_FILE_EXT.value, data_file_path):
             assert IsxdReader.is_available(), "IsxdReader is not available."
             reader = IsxdReader()
-        elif ext == ".thor.zip":
+        elif re.match(MicroscopeDataFileExt.THOR_FILE_EXT.value, data_file_path):
             assert ThorlabsReader.is_available(), "ThorlabsReader is not available."
             reader = ThorlabsReader()
         else:
-            raise Exception(f"Unsupported file type: {ext}")
+            filename = os.path.basename(data_file_path)
+            raise Exception(f"Unsupported file type: {filename}")
 
         reader.load(data_file_path)
 

--- a/studio/app/optinist/microscopes/ThorlabsReader.py
+++ b/studio/app/optinist/microscopes/ThorlabsReader.py
@@ -13,6 +13,9 @@ from studio.app.optinist.microscopes.MicroscopeDataReaderBase import (
     MicroscopeDataReaderBase,
     OMEDataModel,
 )
+from studio.app.optinist.microscopes.MicroscopeDataReaderUtils import (
+    MicroscopeDataFileExt,
+)
 
 
 class ThorlabsReader(MicroscopeDataReaderBase):
@@ -22,7 +25,7 @@ class ThorlabsReader(MicroscopeDataReaderBase):
     #   so any module that supports it (e.g., tifffile) can be used.
     SDK_MODULE_NAME = "tifffile"
 
-    RAW_ARCHIVE_FILE_PATTERN = ".*\\.thor.zip$"
+    RAW_ARCHIVE_FILE_PATTERN = MicroscopeDataFileExt.THOR_FILE_EXT.value
 
     OME_TIFF_EXT = ".tif"
 


### PR DESCRIPTION
- 修正内容
  - Thorlabs のファイル拡張子を正しく判定できていなかったため修正
  - 伴い、MicroscopeDataReaderUtils.get_reader() を refactoring.