### PR TITLE
calculate gsig

### DIFF
--- a/studio/app/optinist/core/nwb/device_metadata.py
+++ b/studio/app/optinist/core/nwb/device_metadata.py
@@ -29,6 +29,10 @@ PIXEL_TYPES = {
     "SizeX": "numeric",
     "SizeY": "numeric",
     "SizeZ": "numeric",
+    "PhysicalSizeX": "numeric",
+    "PhysicalSizeXUnit": "text",
+    "PhysicalSizeY": "numeric",
+    "PhysicalSizeYUnit": "text",
     "SignificantBits": "numeric",
     "Type": "text",
 }


### PR DESCRIPTION
- #288 で追加されたPhysicalSizeに関連し、
  - cnmfパラメータのgSig(細胞の半分の大きさのピクセル数)を計算するロジックを追加
  - PhysicalSizeをNWBファイルに保存する処理を追加