### PR TITLE
Add cleaning of conda cache in dockerfile

### DIFF
--- a/studio/config/docker/Dockerfile
+++ b/studio/config/docker/Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir -p /opt/miniforge && \
     export PATH="$PATH:/opt/miniforge/bin" && \
     conda upgrade -y --all && \
     conda config --set channel_priority flexible && \
-    conda clean -y --tarballs
+    conda clean -y --all
 ENV PATH $PATH:/opt/miniforge/bin
 
 # setup cron
@@ -59,8 +59,8 @@ RUN conda config --set channel_priority flexible && \
 # conda env create
 COPY --chown=optinist studio/app/optinist/wrappers/caiman/conda/caiman_with_expdb.yaml /app/studio/conda_expdb_batch.yaml
 RUN . ~/.bashrc && \
-#    conda create -n expdb_batch -y
-    conda env create -n expdb_batch -f /app/studio/conda_expdb_batch.yaml
+    conda env create -n expdb_batch -f /app/studio/conda_expdb_batch.yaml && \
+    conda clean -y --all --force-pkgs-dirs
 
 # Return to root user
 USER root

--- a/studio/config/docker/Dockerfile.dev
+++ b/studio/config/docker/Dockerfile.dev
@@ -33,7 +33,7 @@ RUN mkdir -p /opt/miniforge && \
     export PATH="$PATH:/opt/miniforge/bin" && \
     conda upgrade -y --all && \
     conda config --set channel_priority flexible && \
-    conda clean -y --tarballs
+    conda clean -y --all
 ENV PATH $PATH:/opt/miniforge/bin
 
 # setup cron
@@ -59,8 +59,8 @@ RUN conda config --set channel_priority flexible && \
 # conda env create
 COPY --chown=optinist studio/app/optinist/wrappers/caiman/conda/caiman_with_expdb.yaml /app/studio/conda_expdb_batch.yaml
 RUN . ~/.bashrc && \
-#    conda create -n expdb_batch -y
-    conda env create -n expdb_batch -f /app/studio/conda_expdb_batch.yaml
+    conda env create -n expdb_batch -f /app/studio/conda_expdb_batch.yaml && \
+    conda clean -y --all --force-pkgs-dirs
 
 # Return to root user
 USER root


### PR DESCRIPTION
### Content

Improved cache cleaning of conda in image to reduce docker image size, since docker image size is large and image build may fail in some environments.

#### Commentary on similar modified PR

The following PRs have similar responses, but with multiple areas of concern.
- #350

##### Concerns

In #350, `~/.conda/pkgs` is moved to /app and volume mounted on the host, but there are the following concerns.
- Permission settings (chmod, chown) from within the Docker container may not work properly due to Docker restrictions.
- When creating a Docker image, `~/.conda/pkgs` is not mounted to the host volume, so it seems that storage capacity is consumed when building the image.
- `~/.conda/pkgs` does not need to be stored persistently.
  - There is also a concern that persistent storage on the host side could lead to inconsistencies in the environment.
- The production version (Dockerfile) is not taken into consideration.

In consideration of the above concerns, this PR simply addresses the issue by "cleaning the conda cache."

### Results

- The docker image size was reduced by about 3GB (12GB → 9GB).

#### Testcase

- [x] Run expdb_batch
- [x] Run caiman from the screen
