### PR TITLE
support multi plot images

### DIFF
--- a/frontend/src/components/Database/DatabaseCells.tsx
+++ b/frontend/src/components/Database/DatabaseCells.tsx
@@ -613,10 +613,9 @@ const DatabaseCells = ({ user }: CellProps) => {
     graphTitle?: string,
   ) => {
     let newData: string | string[] = []
-
     if (Array.isArray(data)) {
-      newData = data.map((d) => d.url)
-    } else newData = data.url
+      newData = data.map((d) => d.urls).flat()
+    } else newData = data.urls
     setDataDialog({
       type: "image",
       data: newData,
@@ -796,7 +795,7 @@ const DatabaseCells = ({ user }: CellProps) => {
             }
           >
             <img
-              src={graph_url.thumb_url}
+              src={graph_url.thumb_urls[0]}
               alt={""}
               width={"100%"}
               height={"100%"}

--- a/frontend/src/components/Database/DatabaseExperiments.tsx
+++ b/frontend/src/components/Database/DatabaseExperiments.tsx
@@ -388,7 +388,7 @@ const columns = (
         >
           {params.row?.cell_image_urls?.length > 0 && (
             <img
-              src={params.row?.cell_image_urls[0].thumb_url}
+              src={params.row?.cell_image_urls[0].thumb_urls[0]}
               alt={""}
               width={"100%"}
               height={"100%"}
@@ -725,8 +725,8 @@ const DatabaseExperiments = ({
   ) => {
     let newData: string | string[] = []
     if (Array.isArray(data)) {
-      newData = data.map((d) => d.url)
-    } else newData = data.url
+      newData = data.map((d) => d.urls).flat()
+    } else newData = data.urls
     setDataDialog({
       type: "image",
       data: newData,
@@ -989,7 +989,7 @@ const DatabaseExperiments = ({
               }
             >
               <img
-                src={graph_url.thumb_url}
+                src={graph_url.thumb_urls[0]}
                 alt={""}
                 width={"100%"}
                 height={"100%"}

--- a/frontend/src/store/slice/Database/DatabaseType.ts
+++ b/frontend/src/store/slice/Database/DatabaseType.ts
@@ -3,8 +3,8 @@ export const DATABASE_SLICE_NAME = "database"
 export type OrderBy = "ASC" | "DESC" | ""
 
 export type ImageUrls = {
-  url: string
-  thumb_url: string
+  urls: string[]
+  thumb_urls: string[]
   params: object
 }
 
@@ -19,11 +19,7 @@ export type DatabaseType = {
   experiment_id?: string
   attributes?: object
   cell_image_urls: ImageUrls[]
-  cell_image_url?: {
-    url: string
-    thumb_url: string
-    params: object
-  }
+  cell_image_url?: ImageUrls
   statistics?: {
     p_value_resp?: string
     p_value_sel?: string
@@ -39,7 +35,7 @@ export type DatabaseType = {
     dir_tuning_width?: string
     ori_tuning_width?: string
   }
-  graph_urls: { url: string; params: object; thumb_url: string }[]
+  graph_urls: ImageUrls[]
   share_type?: number
   publish_status?: number
   created_at: string

--- a/studio/app/optinist/routers/expdb.py
+++ b/studio/app/optinist/routers/expdb.py
@@ -100,7 +100,7 @@ EXPERIMENT_GRAPHS = {
 
 def get_experiment_urls(source, exp_dir, params=None):
     return [
-        ImageInfo(url=f"{exp_dir}/{v['dir']}/{k}.png", params=params)
+        ImageInfo(urls=[f"{exp_dir}/{v['dir']}/{k}.png"], params=params)
         for k, v in source.items()
     ]
 
@@ -113,7 +113,7 @@ def get_pixelmap_urls(exp_dir, params=None):
     )
 
     return [
-        ImageInfo(url=f"{exp_dir}/pixelmaps/{os.path.basename(k)}", params=params)
+        ImageInfo(urls=[f"{exp_dir}/pixelmaps/{os.path.basename(k)}"], params=params)
         for k in pixelmaps
     ]
 
@@ -142,7 +142,7 @@ EXP_ATTRIBUTE_SORT_MAPPING = {
 
 def get_cell_urls(source, exp_dir, index: int, params=None):
     return [
-        ImageInfo(url=f"{exp_dir}/{v['dir']}/{k}_{index}.png", params=params)
+        ImageInfo(urls=[f"{exp_dir}/{v['dir']}/{k}_{index}.png"], params=params)
         for k, v in source.items()
     ]
 
@@ -842,9 +842,6 @@ def update_multiple_experiment_database_share_status(
                     for group_id in data.group_ids
                 )
 
-    db.commit()
-
-    return True
     db.commit()
 
     return True

--- a/studio/app/optinist/schemas/expdb/experiment.py
+++ b/studio/app/optinist/schemas/expdb/experiment.py
@@ -38,14 +38,16 @@ class ExpDbExperimentHeader(BaseModel):
 
 
 class ImageInfo(BaseModel):
-    url: str
-    thumb_url: Optional[str]
+    urls: List[str]
+    thumb_urls: Optional[List[str]]
     params: Optional[dict]
 
-    def __init__(self, url, params=None, thumb_url=None):
-        super().__init__(url=url, thumb_url=thumb_url, params=params)
-        if thumb_url is None:
-            self.thumb_url = url.replace(".png", ".thumb.png")
+    def __init__(self, urls, params=None, thumb_urls=None):
+        if isinstance(urls, str):
+            urls = [urls]
+        super().__init__(urls=urls, thumb_urls=thumb_urls, params=params)
+        if thumb_urls is None:
+            self.thumb_urls = [url.replace(".png", ".thumb.png") for url in urls]
 
 
 class ExpDbExperiment(BaseModel):


### PR DESCRIPTION
In Experiments and Cells View, the popup display of plot images is now supported for multiple images.

### Note

- In this PR, the basic fixes have been applied, but some further fixes are needed for plots that actually have multiple popup images.
  - studio/app/optinist/routers/expdb.py
    - get_experiment_urls()
  - By passing multiple image URLs to `ImageInfo.urls`, multiple Popup images can be displayed as shown below.
  - ![image](https://github.com/user-attachments/assets/abc44d8f-fed4-449f-ad6e-bdf46817bc08)
