### PR TITLE
sparete expdb_dir_path

### DIFF
--- a/run_expdb_dir_migration.py
+++ b/run_expdb_dir_migration.py
@@ -15,6 +15,7 @@ from studio.app.common.core.utils.filepath_creater import (
 )
 from studio.app.const import CELLMASK_SUFFIX, TC_SUFFIX
 from studio.app.dir_path import DIRPATH
+from studio.app.expdb_dir_path import EXPDB_DIRPATH
 
 
 class ExpDbDirMigration:
@@ -55,7 +56,7 @@ class ExpDbDirMigration:
     def __migrate(self):
         subject_dirs = [
             p
-            for p in glob(join_filepath([DIRPATH.EXPDB_DIR, "M*/"]))
+            for p in glob(join_filepath([EXPDB_DIRPATH.EXPDB_DIR, "M*/"]))
             if re.search(r"M\d{6}/", p)
         ]
 

--- a/studio/__main_unit__.py
+++ b/studio/__main_unit__.py
@@ -34,6 +34,7 @@ from studio.app.common.routers import (
     workspace,
 )
 from studio.app.dir_path import DIRPATH
+from studio.app.expdb_dir_path import EXPDB_DIRPATH
 from studio.app.optinist.routers import expdb, hdf5, mat, nwb, roi
 
 
@@ -104,10 +105,10 @@ app.mount(
     name="static",
 )
 
-if DIRPATH.SELFHOST_GRAPH:
+if EXPDB_DIRPATH.SELFHOST_GRAPH:
     app.mount(
         "/datasets",
-        StaticFiles(directory=DIRPATH.PUBLIC_EXPDB_DIR),
+        StaticFiles(directory=EXPDB_DIRPATH.PUBLIC_EXPDB_DIR),
         name="datasets",
     )
 

--- a/studio/app/common/core/rules/file_writer.py
+++ b/studio/app/common/core/rules/file_writer.py
@@ -7,7 +7,7 @@ from studio.app.common.core.snakemake.smk import Rule
 from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.common.dataclass import CsvData, ImageData, TimeSeriesData
 from studio.app.const import EXP_METADATA_SUFFIX, FILETYPE
-from studio.app.dir_path import DIRPATH
+from studio.app.expdb_dir_path import EXPDB_DIRPATH
 from studio.app.optinist.core.nwb.nwb import NWBDATASET
 from studio.app.optinist.dataclass.expdb import ExpDbData
 from studio.app.optinist.dataclass.iscell import IscellData
@@ -128,7 +128,7 @@ class FileWriter:
         subject_id = exp_id.split("_")[0]
         metadata_path = join_filepath(
             [
-                DIRPATH.EXPDB_DIR,
+                EXPDB_DIRPATH.EXPDB_DIR,
                 subject_id,
                 exp_id,
                 f"{exp_id}_{EXP_METADATA_SUFFIX}.json",

--- a/studio/app/common/core/snakemake/smk_utils.py
+++ b/studio/app/common/core/snakemake/smk_utils.py
@@ -11,6 +11,7 @@ from studio.app.common.core.utils.filepath_finder import find_condaenv_filepath
 from studio.app.common.core.workflow.workflow import NodeType, NodeTypeUtil
 from studio.app.const import ACCEPT_FILE_EXT, FILETYPE, TC_SUFFIX, TS_SUFFIX
 from studio.app.dir_path import DIRPATH
+from studio.app.expdb_dir_path import EXPDB_DIRPATH
 from studio.app.wrappers import wrapper_dict
 
 logger = AppLogger.get_logger()
@@ -25,7 +26,7 @@ class SmkUtils:
             elif details["type"] == FILETYPE.MICROSCOPE:
                 exp_id = details["input"]
                 subject_id = exp_id.split("_")[0]
-                exp_dir = join_filepath([DIRPATH.EXPDB_DIR, subject_id, exp_id])
+                exp_dir = join_filepath([EXPDB_DIRPATH.EXPDB_DIR, subject_id, exp_id])
 
                 microscope_files = []
                 for ext in ACCEPT_FILE_EXT.MICROSCOPE_EXT.value:
@@ -44,7 +45,7 @@ class SmkUtils:
                 return [
                     join_filepath(
                         [
-                            DIRPATH.EXPDB_DIR,
+                            EXPDB_DIRPATH.EXPDB_DIR,
                             subject_id,
                             exp_id,
                             f"{exp_id}_{TS_SUFFIX}.mat",
@@ -52,7 +53,7 @@ class SmkUtils:
                     ),
                     join_filepath(
                         [
-                            DIRPATH.EXPDB_DIR,
+                            EXPDB_DIRPATH.EXPDB_DIR,
                             subject_id,
                             exp_id,
                             "preprocess",

--- a/studio/app/dir_path.py
+++ b/studio/app/dir_path.py
@@ -28,24 +28,6 @@ class DIRPATH:
     if os.path.isfile(f"{CONFIG_DIR}/.env"):
         load_dotenv(f"{CONFIG_DIR}/.env")
 
-    load_dotenv(f"{CONFIG_DIR}/.env")
-    EXPDB_DIR = os.environ.get("EXPDB_DIR")
-    assert EXPDB_DIR is not None, "EXPDB_DIR must be set"
-    assert os.path.exists(EXPDB_DIR), f"{EXPDB_DIR} does not exist"
-
-    PUBLIC_EXPDB_DIR = os.environ.get("PUBLIC_EXPDB_DIR")
-    assert PUBLIC_EXPDB_DIR is not None, "PUBLIC_EXPDB_DIR must be set"
-    assert os.path.exists(PUBLIC_EXPDB_DIR), f"{PUBLIC_EXPDB_DIR} does not exist"
-
-    assert (
-        EXPDB_DIR != PUBLIC_EXPDB_DIR
-    ), "EXPDB_DIR and PUBLIC_EXPDB_DIR must be different"
-
-    GRAPH_HOST = os.environ.get("GRAPH_HOST")
-    assert GRAPH_HOST is not None, "GRAPH_HOST must be set"
-
-    SELFHOST_GRAPH = os.environ.get("SELFHOST_GRAPH", True)
-
     CONDAENV_DIR = (
         f"{os.path.dirname(os.path.dirname(os.path.dirname(__file__)))}/conda"
     )
@@ -62,9 +44,6 @@ class DIRPATH:
         if not IS_TEST
         else f"{CONFIG_DIR}/auth/firebase_config.example.json"
     )
-
-    MICROSCOPE_LIB_DIR = f"{APP_DIR}/optinist/microscopes/libs"
-    MICROSCOPE_LIB_ZIP = f"{APP_DIR}/optinist/microscopes/libs.zip"
 
     MICROSCOPE_LIB_DIR = f"{APP_DIR}/optinist/microscopes/libs"
     MICROSCOPE_LIB_ZIP = f"{APP_DIR}/optinist/microscopes/libs.zip"

--- a/studio/app/expdb_dir_path.py
+++ b/studio/app/expdb_dir_path.py
@@ -1,0 +1,26 @@
+import os
+
+from dotenv import load_dotenv
+
+from studio.app.dir_path import DIRPATH
+
+
+class EXPDB_DIRPATH:
+    load_dotenv(f"{DIRPATH.CONFIG_DIR}/.env")
+
+    EXPDB_DIR = os.environ.get("EXPDB_DIR")
+    assert EXPDB_DIR is not None, "EXPDB_DIR must be set"
+    assert os.path.exists(EXPDB_DIR), f"{EXPDB_DIR} does not exist"
+
+    PUBLIC_EXPDB_DIR = os.environ.get("PUBLIC_EXPDB_DIR")
+    assert PUBLIC_EXPDB_DIR is not None, "PUBLIC_EXPDB_DIR must be set"
+    assert os.path.exists(PUBLIC_EXPDB_DIR), f"{PUBLIC_EXPDB_DIR} does not exist"
+
+    assert (
+        EXPDB_DIR != PUBLIC_EXPDB_DIR
+    ), "EXPDB_DIR and PUBLIC_EXPDB_DIR must be different"
+
+    GRAPH_HOST = os.environ.get("GRAPH_HOST")
+    assert GRAPH_HOST is not None, "GRAPH_HOST must be set"
+
+    SELFHOST_GRAPH = os.environ.get("SELFHOST_GRAPH", True)

--- a/studio/app/optinist/core/expdb/batch_runner.py
+++ b/studio/app/optinist/core/expdb/batch_runner.py
@@ -14,6 +14,7 @@ from zc import lockfile
 from studio.app.common.core.users.crud_organizations import get_organization
 from studio.app.common.db.database import session_scope
 from studio.app.dir_path import DIRPATH
+from studio.app.expdb_dir_path import EXPDB_DIRPATH
 from studio.app.optinist.core.expdb.batch_unit import ExpDbBatch
 from studio.app.optinist.core.expdb.crud_cells import bulk_insert_cells
 from studio.app.optinist.core.expdb.crud_configs import summarize_experiment_metadata
@@ -246,11 +247,11 @@ class ExpDbBatchRunner:
         """
         処理対象datasets検索
         """
-        self.logger_.info("path: %s", DIRPATH.EXPDB_DIR)
+        self.logger_.info("path: %s", EXPDB_DIRPATH.EXPDB_DIR)
 
         # フラグファイル検索
         target_flag_files = sorted(
-            glob.glob(DIRPATH.EXPDB_DIR + "/*/*" + FLAG_FILE_EXT)
+            glob.glob(EXPDB_DIRPATH.EXPDB_DIR + "/*/*" + FLAG_FILE_EXT)
         )
 
         return target_flag_files

--- a/studio/app/optinist/core/expdb/batch_unit.py
+++ b/studio/app/optinist/core/expdb/batch_unit.py
@@ -31,7 +31,7 @@ from studio.app.const import (
     THUMBNAIL_HEIGHT,
     TS_SUFFIX,
 )
-from studio.app.dir_path import DIRPATH
+from studio.app.expdb_dir_path import EXPDB_DIRPATH
 from studio.app.optinist.core.expdb.crud_cells import bulk_delete_cells
 from studio.app.optinist.core.expdb.crud_expdb import (
     delete_experiment,
@@ -78,7 +78,7 @@ class ExpDbPath:
         subject_id = exp_id.split("_")[0]
 
         if is_raw:
-            self.exp_dir = join_filepath([DIRPATH.EXPDB_DIR, subject_id, exp_id])
+            self.exp_dir = join_filepath([EXPDB_DIRPATH.EXPDB_DIR, subject_id, exp_id])
             assert os.path.exists(self.exp_dir), f"exp_dir not found: {self.exp_dir}"
             self.output_dir = join_filepath([self.exp_dir, "outputs"])
 
@@ -112,7 +112,9 @@ class ExpDbPath:
                 [self.preprocess_dir, f"{exp_id}_{CELLMASK_SUFFIX}.mat"]
             )
         else:
-            self.exp_dir = join_filepath([DIRPATH.PUBLIC_EXPDB_DIR, subject_id, exp_id])
+            self.exp_dir = join_filepath(
+                [EXPDB_DIRPATH.PUBLIC_EXPDB_DIR, subject_id, exp_id]
+            )
             self.output_dir = self.exp_dir
 
         # outputs

--- a/studio/app/optinist/routers/expdb.py
+++ b/studio/app/optinist/routers/expdb.py
@@ -16,7 +16,7 @@ from studio.app.common.core.auth.auth_dependencies import (
 )
 from studio.app.common.db.database import get_db
 from studio.app.common.schemas.users import User
-from studio.app.dir_path import DIRPATH
+from studio.app.expdb_dir_path import EXPDB_DIRPATH
 from studio.app.optinist import models as optinist_model
 from studio.app.optinist.core.expdb.crud_expdb import extract_experiment_view_attributes
 from studio.app.optinist.schemas.base import SortDirection, SortOptions
@@ -45,7 +45,7 @@ def expdbcell_transformer(items: Sequence) -> Sequence:
     for item in items:
         expdbcell = ExpDbCell.from_orm(item)
         subject_id = expdbcell.experiment_id.split("_")[0]
-        exp_dir = f"{DIRPATH.GRAPH_HOST}/{subject_id}/{expdbcell.experiment_id}"
+        exp_dir = f"{EXPDB_DIRPATH.GRAPH_HOST}/{subject_id}/{expdbcell.experiment_id}"
         try:
             expdbcell.fields = ExpDbExperimentFields(**item.view_attributes)
         except Exception:
@@ -66,7 +66,7 @@ def experiment_transformer(items: Sequence) -> Sequence:
         expdb: optinist_model.Experiment = item
         exp = ExpDbExperiment.from_orm(expdb)
         subject_id = exp.experiment_id.split("_")[0]
-        exp_dir = f"{DIRPATH.GRAPH_HOST}/{subject_id}/{exp.experiment_id}"
+        exp_dir = f"{EXPDB_DIRPATH.GRAPH_HOST}/{subject_id}/{exp.experiment_id}"
 
         try:
             exp.fields = ExpDbExperimentFields(**expdb.view_attributes)
@@ -107,7 +107,7 @@ def get_experiment_urls(source, exp_dir, params=None):
 
 def get_pixelmap_urls(exp_dir, params=None):
     dirs = exp_dir.split("/")
-    pub_dir = f"{DIRPATH.PUBLIC_EXPDB_DIR}/{dirs[-2]}/{dirs[-1]}/pixelmaps/"
+    pub_dir = f"{EXPDB_DIRPATH.PUBLIC_EXPDB_DIR}/{dirs[-2]}/{dirs[-1]}/pixelmaps/"
     pixelmaps = sorted(
         list(set(glob(f"{pub_dir}/*.png")) - set(glob(f"{pub_dir}/*.thumb.png")))
     )

--- a/studio/app/optinist/wrappers/caiman/cnmf_preprocessing.py
+++ b/studio/app/optinist/wrappers/caiman/cnmf_preprocessing.py
@@ -12,7 +12,6 @@ from studio.app.common.core.utils.filepath_creater import (
 )
 from studio.app.common.dataclass import ImageData
 from studio.app.const import CELLMASK_SUFFIX, TC_SUFFIX, TS_SUFFIX
-from studio.app.dir_path import DIRPATH
 from studio.app.optinist.core.nwb.nwb import NWBDATASET
 from studio.app.optinist.dataclass import EditRoiData, FluoData, IscellData, RoiData
 from studio.app.optinist.dataclass.expdb import ExpDbData
@@ -214,6 +213,8 @@ def caiman_cnmf_preprocessing(
     from caiman.source_extraction.cnmf import cnmf, online_cnmf
     from caiman.source_extraction.cnmf.params import CNMFParams
 
+    from studio.app.expdb_dir_path import EXPDB_DIRPATH
+
     function_id = output_dir.split("/")[-1]  # get function_id from output_dir path
     logger.info(f"start caiman_cnmf: {function_id}")
 
@@ -306,7 +307,7 @@ def caiman_cnmf_preprocessing(
     timecourse_path = join_filepath([output_dir, f"{exp_id}_{TC_SUFFIX}.mat"])
     trialstructure_path = join_filepath(
         [
-            DIRPATH.EXPDB_DIR,
+            EXPDB_DIRPATH.EXPDB_DIR,
             exp_id.split("_")[0],
             exp_id,
             f"{exp_id}_{TS_SUFFIX}.mat",


### PR DESCRIPTION
Separate expdb-related dir_path constants into expdb_dir_path

- Purpose of Change
  - To avoid validation when EXPDB_DIRPATH is not used, because EXPDB_DIRPATH validation is strict.

### Testcase

1. Behavior when the path (`EXPDB_DIR` in .env) is correct
    - [x] 1. Start the otpinist application
      - -> Start successfully
    - [x] 2. Run the batch process (run_expdb_batch.py)
      - -> Processing is successful
2. Behavior when the path (`EXPDB_DIR` in .env) is invalid (path that does not exist)
    - [x] 1. Start the otpinist application
      - -> Start fails (AssertionError)
    - [x] 2. Run the batch process (run_expdb_batch.py)
      - -> Processing fails (AssertionError)
    - [x] 3. Run a program that does not reference EXPDB_DIRPATH (such as tutorial notebook)
      - -> There is no impact (no exception occurs) even if the contents of EXPDB_DIRPATH are invalid
