### PR TITLE
update param structure to match v2 style

### DIFF
--- a/studio/app/optinist/wrappers/caiman/params/caiman_cnmf_preprocessing.production.yaml
+++ b/studio/app/optinist/wrappers/caiman/params/caiman_cnmf_preprocessing.production.yaml
@@ -47,12 +47,6 @@ patch_params:
 merge_params:
   merge_thr: 0.80
 
-quality_params:
-  min_SNR: 2.0
-
-temporal_params:
-  rval_thr: 0.5
-  min_cnn_thr: 0.2
 
 # ----------------------------------------
 # Advanced Parameters
@@ -135,7 +129,10 @@ advanced:
     SNR_lowest: 0.5
     cnn_lowest: 0.1
     gSig_range: null
+    min_SNR: 2.0
+    min_cnn_thr: 0.2
     rval_lowest: -1
+    rval_thr: 0.5
     use_cnn: True
     use_ecc: False
     max_ecc: 3

--- a/studio/app/optinist/wrappers/caiman/params/caiman_cnmf_preprocessing.yaml
+++ b/studio/app/optinist/wrappers/caiman/params/caiman_cnmf_preprocessing.yaml
@@ -47,12 +47,6 @@ patch_params:
 merge_params:
   merge_thr: 0.80
 
-quality_params:
-  min_SNR: 2.0
-
-temporal_params:
-  rval_thr: 0.5
-  min_cnn_thr: 0.2
 
 # ----------------------------------------
 # Advanced Parameters
@@ -135,7 +129,10 @@ advanced:
     SNR_lowest: 0.5
     cnn_lowest: 0.1
     gSig_range: null
+    min_SNR: 2.0
+    min_cnn_thr: 0.2
     rval_lowest: -1
+    rval_thr: 0.5
     use_cnn: True
     use_ecc: False
     max_ecc: 3


### PR DESCRIPTION
Response to https://github.com/arayabrain/barebone-studio/issues/653

It seems that nested structure is preferred 

> 2025-03-24 15:56:06,777 WARNING: change_params():1156 - In setting CNMFParams, non-pathed parameters were used; this is deprecated. In some future version of Caiman, allow_legacy will default to False (and eventually will be removed)
> 2025-03-24 15:56:06,781 WARNING: change_params():1162 - In setting CNMFParams, provided toplevel key max_merge_area was unused. This is a bug!
> 2025-03-24 15:56:06,990 WARNING: setup_cluster():225 - The local backend is an alias for the multiprocessing backend, and the alias may be removed in some future version of Caiman
> 2025-03-24 15:56:07,139 WARNING: change_params():1156 - In setting CNMFParams, non-pathed parameters were used; this is deprecated. In some future version of Caiman, allow_legacy will default to False (and eventually will be removed)

So i should change cnmf and cnmf_preprocessing to use official nested structure