### PR TITLE
Porting optinist microscope node

### DIFF
--- a/frontend/src/api/files/Files.ts
+++ b/frontend/src/api/files/Files.ts
@@ -11,6 +11,7 @@ export const FILE_TREE_TYPE_SET = {
   BEHAVIOR: "behavior",
   MATLAB: "matlab",
   MICROSCOPE: "microscope",
+  MICROSCOPE_EXPDB: "microscope_expdb",
   EXPDB: "expdb",
   ALL: "all",
 } as const

--- a/frontend/src/components/Workspace/FlowChart/FlowChartNode/ExpDbNode.tsx
+++ b/frontend/src/components/Workspace/FlowChart/FlowChartNode/ExpDbNode.tsx
@@ -16,7 +16,10 @@ import { GridEventListener, GridRowParams } from "@mui/x-data-grid"
 
 import DatabaseExperiments from "components/Database/DatabaseExperiments"
 import { DialogContext } from "components/Workspace/FlowChart/Dialog/DialogContext"
-import { isValidConnection, toHandleId } from "components/Workspace/FlowChart/FlowChartNode/FlowChartUtils"
+import {
+  isValidConnection,
+  toHandleId,
+} from "components/Workspace/FlowChart/FlowChartNode/FlowChartUtils"
 import { useHandleColor } from "components/Workspace/FlowChart/FlowChartNode/HandleColorHook"
 import { NodeContainer } from "components/Workspace/FlowChart/FlowChartNode/NodeContainer"
 import { HANDLE_STYLE } from "const/flowchart"
@@ -27,6 +30,7 @@ import {
   selectExpDbInputNodeSelectedFilePath,
   selectInputNodeDefined,
 } from "store/slice/InputNode/InputNodeSelectors"
+import { FILE_TYPE_NODE_NAME_ALIAS } from "store/slice/InputNode/InputNodeType"
 import { selectPipelineLatestUid } from "store/slice/Pipeline/PipelineSelectors"
 import { selectCurrentUser } from "store/slice/User/UserSelector"
 import { RootState } from "store/store"
@@ -80,7 +84,7 @@ const ExpDbSelect = memo(function ExpDbSelect({ nodeId }: { nodeId: string }) {
 
   return (
     <div>
-      <Typography>preprocessed_data</Typography>
+      <Typography>{FILE_TYPE_NODE_NAME_ALIAS.EXPDB}</Typography>
       <Button size="small" variant="outlined" onClick={() => setOpen(true)}>
         Select
       </Button>

--- a/frontend/src/components/Workspace/FlowChart/FlowChartNode/FileSelect.tsx
+++ b/frontend/src/components/Workspace/FlowChart/FlowChartNode/FileSelect.tsx
@@ -307,6 +307,8 @@ function getFileInputAccept(fileType: FILE_TREE_TYPE | undefined) {
       return ".hdf5,.nwb"
     case FILE_TREE_TYPE_SET.MICROSCOPE:
       return ".nd2,.oir,.isxd,.thor.zip"
+    case FILE_TREE_TYPE_SET.MICROSCOPE_EXPDB:
+      return ".nd2,.oir,.isxd,.thor.zip"
     default:
       return undefined
   }

--- a/frontend/src/components/Workspace/FlowChart/FlowChartNode/MicroscopeExpdbFileNode.tsx
+++ b/frontend/src/components/Workspace/FlowChart/FlowChartNode/MicroscopeExpdbFileNode.tsx
@@ -1,0 +1,94 @@
+import { memo, useState } from "react"
+import { useSelector, useDispatch } from "react-redux"
+import { Handle, Position, NodeProps } from "reactflow"
+
+import { Button, Typography } from "@mui/material"
+
+import { ExpDbSelectDialog } from "components/Workspace/FlowChart/FlowChartNode/ExpDbNode"
+import {
+  toHandleId,
+  isValidConnection,
+} from "components/Workspace/FlowChart/FlowChartNode/FlowChartUtils"
+import { useHandleColor } from "components/Workspace/FlowChart/FlowChartNode/HandleColorHook"
+import { NodeContainer } from "components/Workspace/FlowChart/FlowChartNode/NodeContainer"
+import { HANDLE_STYLE } from "const/flowchart"
+import { deleteFlowNodeById } from "store/slice/FlowElement/FlowElementSlice"
+import {
+  selectMicroscopeExpdbInputNodeSelectedFilePath,
+  selectInputNodeDefined,
+} from "store/slice/InputNode/InputNodeSelectors"
+import { FILE_TYPE_NODE_NAME_ALIAS } from "store/slice/InputNode/InputNodeType"
+
+export const MicroscopeExpdbFileNode = memo(function MicroscopeExpdbFileNode(
+  element: NodeProps,
+) {
+  const defined = useSelector(selectInputNodeDefined(element.id))
+  if (defined) {
+    return <MicroscopeExpdbFileNodeImple {...element} />
+  } else {
+    return null
+  }
+})
+
+const MicroscopeExpdbFileNodeImple = memo(
+  function MicroscopeExpdbFileNodeImple({
+    id: nodeId,
+    selected: elementSelected,
+  }: NodeProps) {
+    const dispatch = useDispatch()
+
+    const returnType = "MicroscopeExpdbData"
+    const microscopeColor = useHandleColor(returnType)
+
+    const onClickDeleteIcon = () => {
+      dispatch(deleteFlowNodeById(nodeId))
+    }
+
+    return (
+      <NodeContainer nodeId={nodeId} selected={elementSelected}>
+        <Typography>{FILE_TYPE_NODE_NAME_ALIAS.MICROSCOPE_EXPDB}</Typography>
+        <button
+          className="flowbutton"
+          onClick={onClickDeleteIcon}
+          style={{ color: "black", position: "absolute", top: -10, right: 10 }}
+        >
+          ×
+        </button>
+        <ExpDbSelect nodeId={nodeId} />
+        <Handle
+          type="source"
+          position={Position.Right}
+          id={toHandleId(nodeId, "microscope", returnType)}
+          style={{ ...HANDLE_STYLE, background: microscopeColor }}
+          isValidConnection={isValidConnection}
+        />
+      </NodeContainer>
+    )
+  },
+)
+
+const ExpDbSelect = memo(function ExpDbSelect({ nodeId }: { nodeId: string }) {
+  const [open, setOpen] = useState(false)
+  const experimentId = useSelector(
+    selectMicroscopeExpdbInputNodeSelectedFilePath(nodeId),
+  )
+
+  return (
+    <div>
+      <Button size="small" variant="outlined" onClick={() => setOpen(true)}>
+        Select
+      </Button>
+      <ExpDbSelectDialog
+        nodeId={nodeId}
+        open={open}
+        setOpen={setOpen}
+        experimentIdSelector={selectMicroscopeExpdbInputNodeSelectedFilePath}
+      />
+      <Typography>
+        {experimentId
+          ? `Selected experiment id: ${experimentId}`
+          : "No experiment selected"}
+      </Typography>
+    </div>
+  )
+})

--- a/frontend/src/components/Workspace/FlowChart/FlowChartNode/MicroscopeFileNode.tsx
+++ b/frontend/src/components/Workspace/FlowChart/FlowChartNode/MicroscopeFileNode.tsx
@@ -1,10 +1,8 @@
-import { memo, useState } from "react"
+import { memo } from "react"
 import { useSelector, useDispatch } from "react-redux"
 import { Handle, Position, NodeProps } from "reactflow"
 
-import { Button, Typography } from "@mui/material"
-
-import { ExpDbSelectDialog } from "components/Workspace/FlowChart/FlowChartNode/ExpDbNode"
+import { FileSelect } from "components/Workspace/FlowChart/FlowChartNode/FileSelect"
 import {
   toHandleId,
   isValidConnection,
@@ -13,10 +11,12 @@ import { useHandleColor } from "components/Workspace/FlowChart/FlowChartNode/Han
 import { NodeContainer } from "components/Workspace/FlowChart/FlowChartNode/NodeContainer"
 import { HANDLE_STYLE } from "const/flowchart"
 import { deleteFlowNodeById } from "store/slice/FlowElement/FlowElementSlice"
+import { setInputNodeFilePath } from "store/slice/InputNode/InputNodeActions"
 import {
   selectMicroscopeInputNodeSelectedFilePath,
   selectInputNodeDefined,
 } from "store/slice/InputNode/InputNodeSelectors"
+import { FILE_TYPE_SET } from "store/slice/InputNode/InputNodeType"
 
 export const MicroscopeFileNode = memo(function MicroscopeFileNode(
   element: NodeProps,
@@ -34,6 +34,12 @@ const MicroscopeFileNodeImple = memo(function MicroscopeFileNodeImple({
   selected: elementSelected,
 }: NodeProps) {
   const dispatch = useDispatch()
+  const filePath = useSelector(
+    selectMicroscopeInputNodeSelectedFilePath(nodeId),
+  )
+  const onChangeFilePath = (path: string) => {
+    dispatch(setInputNodeFilePath({ nodeId, filePath: path }))
+  }
 
   const returnType = "MicroscopeData"
   const microscopeColor = useHandleColor(returnType)
@@ -44,7 +50,6 @@ const MicroscopeFileNodeImple = memo(function MicroscopeFileNodeImple({
 
   return (
     <NodeContainer nodeId={nodeId} selected={elementSelected}>
-      <Typography>microscope</Typography>
       <button
         className="flowbutton"
         onClick={onClickDeleteIcon}
@@ -52,40 +57,26 @@ const MicroscopeFileNodeImple = memo(function MicroscopeFileNodeImple({
       >
         ×
       </button>
-      <ExpDbSelect nodeId={nodeId} />
+      <FileSelect
+        nodeId={nodeId}
+        onChangeFilePath={(path) => {
+          if (!Array.isArray(path)) {
+            onChangeFilePath(path)
+          }
+        }}
+        fileType={FILE_TYPE_SET.MICROSCOPE}
+        filePath={filePath ?? ""}
+      />
       <Handle
         type="source"
         position={Position.Right}
         id={toHandleId(nodeId, "microscope", returnType)}
-        style={{ ...HANDLE_STYLE, background: microscopeColor }}
+        style={{
+          ...HANDLE_STYLE,
+          background: microscopeColor,
+        }}
         isValidConnection={isValidConnection}
       />
     </NodeContainer>
-  )
-})
-
-const ExpDbSelect = memo(function ExpDbSelect({ nodeId }: { nodeId: string }) {
-  const [open, setOpen] = useState(false)
-  const experimentId = useSelector(
-    selectMicroscopeInputNodeSelectedFilePath(nodeId),
-  )
-
-  return (
-    <div>
-      <Button size="small" variant="outlined" onClick={() => setOpen(true)}>
-        Select
-      </Button>
-      <ExpDbSelectDialog
-        nodeId={nodeId}
-        open={open}
-        setOpen={setOpen}
-        experimentIdSelector={selectMicroscopeInputNodeSelectedFilePath}
-      />
-      <Typography>
-        {experimentId
-          ? `Selected experiment id: ${experimentId}`
-          : "No experiment selected"}
-      </Typography>
-    </div>
   )
 })

--- a/frontend/src/components/Workspace/FlowChart/FlowChartNode/ReactFlowNodeTypesConst.ts
+++ b/frontend/src/components/Workspace/FlowChart/FlowChartNode/ReactFlowNodeTypesConst.ts
@@ -7,6 +7,7 @@ import { FluoFileNode } from "components/Workspace/FlowChart/FlowChartNode/FluoF
 import { HDF5FileNode } from "components/Workspace/FlowChart/FlowChartNode/HDF5FileNode"
 import { ImageFileNode } from "components/Workspace/FlowChart/FlowChartNode/ImageFileNode"
 import { MatlabFileNode } from "components/Workspace/FlowChart/FlowChartNode/MatlabFileNode"
+import { MicroscopeExpdbFileNode } from "components/Workspace/FlowChart/FlowChartNode/MicroscopeExpdbFileNode"
 import { MicroscopeFileNode } from "components/Workspace/FlowChart/FlowChartNode/MicroscopeFileNode"
 
 export const reactFlowNodeTypes = {
@@ -18,6 +19,7 @@ export const reactFlowNodeTypes = {
   FluoFileNode,
   BehaviorFileNode,
   MicroscopeFileNode,
+  MicroscopeExpdbFileNode,
   ExpDbNode,
 } as const
 

--- a/frontend/src/components/Workspace/FlowChart/TreeView.tsx
+++ b/frontend/src/components/Workspace/FlowChart/TreeView.tsx
@@ -37,7 +37,11 @@ import {
   NODE_TYPE,
   NODE_TYPE_SET,
 } from "store/slice/FlowElement/FlowElementType"
-import { FILE_TYPE, FILE_TYPE_SET } from "store/slice/InputNode/InputNodeType"
+import {
+  FILE_TYPE,
+  FILE_TYPE_NODE_NAME_ALIAS,
+  FILE_TYPE_SET,
+} from "store/slice/InputNode/InputNodeType"
 import { selectPipelineLatestUid } from "store/slice/Pipeline/PipelineSelectors"
 import { AppDispatch } from "store/store"
 import { getNanoId } from "utils/nanoid/NanoIdUtils"
@@ -126,10 +130,16 @@ export const AlgorithmTreeView = memo(function AlgorithmTreeView() {
           fileType={FILE_TYPE_SET.MICROSCOPE}
         />
         <InputNodeComponent
+          fileName={"microscopeExpdb"}
+          nodeName={"MicroscopeExpdbData"}
+          fileType={FILE_TYPE_SET.MICROSCOPE_EXPDB}
+          displayName={FILE_TYPE_NODE_NAME_ALIAS.MICROSCOPE_EXPDB}
+        />
+        <InputNodeComponent
           fileName={"expdbPreprocessed"}
           nodeName={"expdbPreprocessedData"}
           fileType={FILE_TYPE_SET.EXPDB}
-          displayName="preprocessed_data"
+          displayName={FILE_TYPE_NODE_NAME_ALIAS.EXPDB}
         />
       </TreeItem>
       <TreeItem nodeId="Algorithm" label="Algorithm">
@@ -196,6 +206,10 @@ const InputNodeComponent = memo(function InputNodeComponent({
         case FILE_TYPE_SET.MICROSCOPE:
           reactFlowNodeType = REACT_FLOW_NODE_TYPE_KEY.MicroscopeFileNode
           fileType = FILE_TYPE_SET.MICROSCOPE
+          break
+        case FILE_TYPE_SET.MICROSCOPE_EXPDB:
+          reactFlowNodeType = REACT_FLOW_NODE_TYPE_KEY.MicroscopeExpdbFileNode
+          fileType = FILE_TYPE_SET.MICROSCOPE_EXPDB
           break
         case FILE_TYPE_SET.EXPDB:
           reactFlowNodeType = REACT_FLOW_NODE_TYPE_KEY.ExpDbNode

--- a/frontend/src/components/Workspace/Visualize/FilePathSelect.tsx
+++ b/frontend/src/components/Workspace/Visualize/FilePathSelect.tsx
@@ -229,6 +229,7 @@ function toDataTypeFromFileType(fileType: FILE_TYPE) {
       return DATA_TYPE_SET.BEHAVIOR
     case FILE_TYPE_SET.MATLAB:
     case FILE_TYPE_SET.MICROSCOPE:
+    case FILE_TYPE_SET.MICROSCOPE_EXPDB:
     case FILE_TYPE_SET.EXPDB:
       return DATA_TYPE_SET.MATLAB
   }

--- a/frontend/src/components/Workspace/__tests__/FlowChart/TreeView.test.tsx
+++ b/frontend/src/components/Workspace/__tests__/FlowChart/TreeView.test.tsx
@@ -64,6 +64,7 @@ describe.skip("AlgorithmTreeView", () => {
     expect(screen.getByText("behavior")).toBeInTheDocument()
     expect(screen.getByText("matlab")).toBeInTheDocument()
     expect(screen.getByText("microscope")).toBeInTheDocument()
+    expect(screen.getByText("microscope_database")).toBeInTheDocument()
   })
 
   it("renders the AlgorithmTree Algorithm TreeItems", async () => {

--- a/frontend/src/const/flowchart.ts
+++ b/frontend/src/const/flowchart.ts
@@ -35,6 +35,7 @@ export const REACT_FLOW_NODE_TYPE_KEY = {
   BehaviorFileNode: "BehaviorFileNode",
   MatlabFileNode: "MatlabFileNode",
   MicroscopeFileNode: "MicroscopeFileNode",
+  MicroscopeExpdbFileNode: "MicroscopeExpdbFileNode",
   ExpDbNode: "ExpDbNode",
 } as const
 

--- a/frontend/src/store/slice/HandleTypeColor/HandleTypeColorSlice.ts
+++ b/frontend/src/store/slice/HandleTypeColor/HandleTypeColorSlice.ts
@@ -18,9 +18,10 @@ const initialState: HandleTypeColor = {
     FluoData: MuiColors.orange[500],
     SpikingActivityData: MuiColors.orange[500],
     BehaviorData: MuiColors.yellow[500],
+    MicroscopeData: MuiColors.purple[500],
+    MicroscopeExpdbData: MuiColors.purple[200],
     ExpDbData: MuiColors.blue[300],
     StatData: MuiColors.blue[800],
-    MicroscopeData: MuiColors.purple[500],
   },
   nextKey: 0,
 }

--- a/frontend/src/store/slice/InputNode/InputNodeSelectors.ts
+++ b/frontend/src/store/slice/InputNode/InputNodeSelectors.ts
@@ -3,8 +3,9 @@ import {
   isCsvInputNode,
   isImageInputNode,
   isMatlabInputNode,
-  isExpDbInputNode,
   isMicroscopeInputNode,
+  isMicroscopeExpDbInputNode,
+  isExpDbInputNode,
 } from "store/slice/InputNode/InputNodeUtils"
 import { RootState } from "store/store"
 
@@ -130,6 +131,16 @@ export const selectInputNodeMatlabPath =
       return item.matPath
     } else {
       return undefined
+    }
+  }
+
+export const selectMicroscopeExpdbInputNodeSelectedFilePath =
+  (nodeId: string) => (state: RootState) => {
+    const node = selectInputNodeById(nodeId)(state)
+    if (isMicroscopeExpDbInputNode(node)) {
+      return node.selectedFilePath
+    } else {
+      throw new Error("invalid input node type")
     }
   }
 

--- a/frontend/src/store/slice/InputNode/InputNodeSlice.ts
+++ b/frontend/src/store/slice/InputNode/InputNodeSlice.ts
@@ -150,6 +150,12 @@ export const inputNodeSlice = createSlice({
                 param: {},
               }
               break
+            case FILE_TYPE_SET.MICROSCOPE_EXPDB:
+              state[node.id] = {
+                fileType,
+                param: {},
+              }
+              break
             case FILE_TYPE_SET.EXPDB:
               state[node.id] = {
                 fileType,
@@ -216,6 +222,13 @@ export const inputNodeSlice = createSlice({
                   fileType: FILE_TYPE_SET.MICROSCOPE,
                   param: {},
                 }
+              } else if (
+                node.data.fileType === FILE_TYPE_SET.MICROSCOPE_EXPDB
+              ) {
+                newState[node.id] = {
+                  fileType: FILE_TYPE_SET.MICROSCOPE_EXPDB,
+                  param: {},
+                }
               } else if (node.data.fileType === FILE_TYPE_SET.EXPDB) {
                 newState[node.id] = {
                   fileType: FILE_TYPE_SET.EXPDB,
@@ -263,6 +276,14 @@ export const inputNodeSlice = createSlice({
                 } else if (node.data.fileType === FILE_TYPE_SET.MICROSCOPE) {
                   newState[node.id] = {
                     fileType: FILE_TYPE_SET.MICROSCOPE,
+                    selectedFilePath: node.data.path as string,
+                    param: {},
+                  }
+                } else if (
+                  node.data.fileType === FILE_TYPE_SET.MICROSCOPE_EXPDB
+                ) {
+                  newState[node.id] = {
+                    fileType: FILE_TYPE_SET.MICROSCOPE_EXPDB,
                     selectedFilePath: node.data.path as string,
                     param: {},
                   }

--- a/frontend/src/store/slice/InputNode/InputNodeType.ts
+++ b/frontend/src/store/slice/InputNode/InputNodeType.ts
@@ -8,7 +8,13 @@ export const FILE_TYPE_SET = {
   BEHAVIOR: "behavior",
   MATLAB: "matlab",
   MICROSCOPE: "microscope",
+  MICROSCOPE_EXPDB: "microscope_expdb",
   EXPDB: "expdb",
+} as const
+
+export const FILE_TYPE_NODE_NAME_ALIAS = {
+  MICROSCOPE_EXPDB: "microscope_database",
+  EXPDB: "preprocessed_data",
 } as const
 
 export type FILE_TYPE = (typeof FILE_TYPE_SET)[keyof typeof FILE_TYPE_SET]
@@ -23,8 +29,8 @@ export type InputNodeType =
   | HDF5InputNode
   | MatlabInputNode
   | MicroscopeInputNode
+  | MicroscopeExpdbInputNode
   | ExpDbInputNode
-  | MicroscopeInputNode
 
 interface InputNodeBaseType<
   T extends FILE_TYPE,
@@ -65,6 +71,11 @@ export interface HDF5InputNode
 
 export interface MicroscopeInputNode
   extends InputNodeBaseType<"microscope", Record<never, never>> {
+  selectedFilePath?: string
+}
+
+export interface MicroscopeExpdbInputNode
+  extends InputNodeBaseType<"microscope_expdb", Record<never, never>> {
   selectedFilePath?: string
 }
 

--- a/frontend/src/store/slice/InputNode/InputNodeUtils.ts
+++ b/frontend/src/store/slice/InputNode/InputNodeUtils.ts
@@ -7,6 +7,7 @@ import {
   FILE_TYPE_SET,
   MatlabInputNode,
   MicroscopeInputNode,
+  MicroscopeExpdbInputNode,
 } from "store/slice/InputNode/InputNodeType"
 
 export function isImageInputNode(
@@ -37,6 +38,12 @@ export function isMicroscopeInputNode(
   inputNode: InputNodeType,
 ): inputNode is MicroscopeInputNode {
   return inputNode.fileType === FILE_TYPE_SET.MICROSCOPE
+}
+
+export function isMicroscopeExpDbInputNode(
+  inputNode: InputNodeType,
+): inputNode is MicroscopeExpdbInputNode {
+  return inputNode.fileType === FILE_TYPE_SET.MICROSCOPE_EXPDB
 }
 
 export function isExpDbInputNode(

--- a/studio/app/common/core/rules/data.py
+++ b/studio/app/common/core/rules/data.py
@@ -47,6 +47,8 @@ def main():
             outputfile = FileWriter.mat(rule_config)
         elif rule_config.type == FILETYPE.MICROSCOPE:
             outputfile = FileWriter.microscope(rule_config)
+        elif rule_config.type == FILETYPE.MICROSCOPE_EXPDB:
+            outputfile = FileWriter.microscope_expdb(rule_config)
         elif rule_config.type == FILETYPE.EXPDB:
             outputfile = FileWriter.exp_db(rule_config)
         else:

--- a/studio/app/common/core/rules/file_writer.py
+++ b/studio/app/common/core/rules/file_writer.py
@@ -12,6 +12,7 @@ from studio.app.optinist.core.nwb.nwb import NWBDATASET
 from studio.app.optinist.dataclass.expdb import ExpDbData
 from studio.app.optinist.dataclass.iscell import IscellData
 from studio.app.optinist.dataclass.microscope import MicroscopeData
+from studio.app.optinist.dataclass.microscope_expdb import MicroscopeExpdbData
 from studio.app.optinist.routers.mat import MatGetter
 
 
@@ -68,6 +69,14 @@ class FileWriter:
     @classmethod
     def microscope(cls, rule_config: Rule):
         info = {rule_config.return_arg: MicroscopeData(rule_config.input)}
+        nwbfile = rule_config.nwbfile
+        nwbfile["image_series"]["external_file"] = info[rule_config.return_arg]
+        info["nwbfile"] = {"input": nwbfile}
+        return info
+
+    @classmethod
+    def microscope_expdb(cls, rule_config: Rule):
+        info = {rule_config.return_arg: MicroscopeExpdbData(rule_config.input)}
         nwbfile = rule_config.nwbfile
         nwbfile["image_series"]["external_file"] = info[rule_config.return_arg]
 

--- a/studio/app/common/core/snakemake/smk_utils.py
+++ b/studio/app/common/core/snakemake/smk_utils.py
@@ -20,16 +20,6 @@ logger = AppLogger.get_logger()
 class SmkUtils:
     @classmethod
     def input(cls, details):
-
-        logger.debug("======================================================  input:")
-        logger.debug(details)
-        logger.debug(details["type"])
-        # print(
-        #     "======================================================  input:",
-        #     details,
-        #     details["type"],
-        # )
-
         if NodeTypeUtil.check_nodetype_from_filetype(details["type"]) == NodeType.DATA:
             if details["type"] in [FILETYPE.IMAGE]:
                 return [join_filepath([DIRPATH.INPUT_DIR, x]) for x in details["input"]]
@@ -47,13 +37,6 @@ class SmkUtils:
                 ), "No Microscope data file found. " + str(
                     ACCEPT_FILE_EXT.MICROSCOPE_EXPDB_EXT.value
                 )
-
-                logger.debug(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> microscope_files:")
-                logger.debug(microscope_files)
-                # print(
-                #     ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> microscope_files:",
-                #     microscope_files,
-                # )
 
                 return microscope_files
             elif details["type"] == FILETYPE.EXPDB:

--- a/studio/app/common/core/snakemake/smk_utils.py
+++ b/studio/app/common/core/snakemake/smk_utils.py
@@ -20,23 +20,40 @@ logger = AppLogger.get_logger()
 class SmkUtils:
     @classmethod
     def input(cls, details):
+
+        logger.debug("======================================================  input:")
+        logger.debug(details)
+        logger.debug(details["type"])
+        # print(
+        #     "======================================================  input:",
+        #     details,
+        #     details["type"],
+        # )
+
         if NodeTypeUtil.check_nodetype_from_filetype(details["type"]) == NodeType.DATA:
             if details["type"] in [FILETYPE.IMAGE]:
                 return [join_filepath([DIRPATH.INPUT_DIR, x]) for x in details["input"]]
-            elif details["type"] == FILETYPE.MICROSCOPE:
+            elif details["type"] == FILETYPE.MICROSCOPE_EXPDB:
                 exp_id = details["input"]
                 subject_id = exp_id.split("_")[0]
                 exp_dir = join_filepath([EXPDB_DIRPATH.EXPDB_DIR, subject_id, exp_id])
 
                 microscope_files = []
-                for ext in ACCEPT_FILE_EXT.MICROSCOPE_EXT.value:
+                for ext in ACCEPT_FILE_EXT.MICROSCOPE_EXPDB_EXT.value:
                     microscope_files.extend(glob(join_filepath([exp_dir, f"*{ext}"])))
 
                 assert (
                     len(microscope_files) > 0
                 ), "No Microscope data file found. " + str(
-                    ACCEPT_FILE_EXT.MICROSCOPE_EXT.value
+                    ACCEPT_FILE_EXT.MICROSCOPE_EXPDB_EXT.value
                 )
+
+                logger.debug(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> microscope_files:")
+                logger.debug(microscope_files)
+                # print(
+                #     ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> microscope_files:",
+                #     microscope_files,
+                # )
 
                 return microscope_files
             elif details["type"] == FILETYPE.EXPDB:

--- a/studio/app/common/core/snakemake/snakemake_rule.py
+++ b/studio/app/common/core/snakemake/snakemake_rule.py
@@ -64,9 +64,12 @@ class SmkRule:
         )
 
     def microscope(self) -> Rule:
+        return self.builder.set_type(FILETYPE.MICROSCOPE).build()
+
+    def microscope_expdb(self) -> Rule:
         return (
             self.builder.set_input(self._node.data.path)
-            .set_type(FILETYPE.MICROSCOPE)
+            .set_type(FILETYPE.MICROSCOPE_EXPDB)
             .build()
         )
 

--- a/studio/app/common/core/workflow/workflow.py
+++ b/studio/app/common/core/workflow/workflow.py
@@ -58,6 +58,7 @@ class NodeType:
     HDF5: str = "HDF5FileNode"
     MATLAB: str = "MatlabFileNode"
     MICROSCOPE: str = "MicroscopeFileNode"
+    MICROSCOPE_EXPDB: str = "MicroscopeExpdbFileNode"
     EXPDB: str = "ExpDbNode"
 
     # Data Type (Includes above DataType Nodes)
@@ -81,6 +82,7 @@ class NodeTypeUtil:
             NodeType.HDF5,
             NodeType.MATLAB,
             NodeType.MICROSCOPE,
+            NodeType.MICROSCOPE_EXPDB,
             NodeType.EXPDB,
         ]:
             return NodeType.DATA
@@ -101,6 +103,7 @@ class NodeTypeUtil:
             FILETYPE.HDF5,
             FILETYPE.MATLAB,
             FILETYPE.MICROSCOPE,
+            FILETYPE.MICROSCOPE_EXPDB,
             FILETYPE.EXPDB,
         ]:
             return NodeType.DATA

--- a/studio/app/common/core/workflow/workflow_runner.py
+++ b/studio/app/common/core/workflow/workflow_runner.py
@@ -134,6 +134,8 @@ class WorkflowRunner:
                     data_rule = data_common_rule.mat()
                 elif node.type == NodeType.MICROSCOPE:
                     data_rule = data_common_rule.microscope()
+                elif node.type == NodeType.MICROSCOPE_EXPDB:
+                    data_rule = data_common_rule.microscope_expdb()
                 elif node.type == NodeType.EXPDB:
                     data_rule = data_common_rule.expdb()
 

--- a/studio/app/const.py
+++ b/studio/app/const.py
@@ -10,6 +10,7 @@ class FILETYPE:
     BEHAVIOR: str = "behavior"
     MATLAB: str = "matlab"
     MICROSCOPE: str = "microscope"
+    MICROSCOPE_EXPDB: str = "microscope_expdb"
     EXPDB: str = "expdb"
 
 
@@ -19,9 +20,17 @@ class ACCEPT_FILE_EXT(Enum):
     HDF5_EXT = [".hdf5", ".nwb", ".HDF5", ".NWB"]
     MATLAB_EXT = [".mat"]
     MICROSCOPE_EXT = [".nd2", ".oir", ".isxd", ".thor.zip", ".xml"]
+    MICROSCOPE_EXPDB_EXT = [".nd2", ".oir", ".isxd", ".thor.zip", ".xml"]
     EXPDB = []  # Note: EXPDB does not have a file ext.
 
-    ALL_EXT = TIFF_EXT + CSV_EXT + HDF5_EXT + MATLAB_EXT + MICROSCOPE_EXT
+    ALL_EXT = (
+        TIFF_EXT
+        + CSV_EXT
+        + HDF5_EXT
+        + MATLAB_EXT
+        + MICROSCOPE_EXT
+        + MICROSCOPE_EXPDB_EXT
+    )
 
 
 ORIGINAL_DATA_EXT = ".orig"

--- a/studio/app/optinist/core/expdb/batch_unit.py
+++ b/studio/app/optinist/core/expdb/batch_unit.py
@@ -41,7 +41,7 @@ from studio.app.optinist.core.expdb.crud_expdb import (
 from studio.app.optinist.core.nwb.nwb import NWBDATASET
 from studio.app.optinist.core.nwb.nwb_creater import save_nwb
 from studio.app.optinist.dataclass import ExpDbData, StatData
-from studio.app.optinist.dataclass.microscope import MicroscopeData
+from studio.app.optinist.dataclass.microscope_expdb import MicroscopeExpdbData
 from studio.app.optinist.wrappers.caiman.cnmf_preprocessing import (
     caiman_cnmf_preprocessing,
 )
@@ -92,7 +92,7 @@ class ExpDbPath:
 
             # input_files
             microscope_files = []
-            for ext in ACCEPT_FILE_EXT.MICROSCOPE_EXT.value:
+            for ext in ACCEPT_FILE_EXT.MICROSCOPE_EXPDB_EXT.value:
                 microscope_files.extend(glob(join_filepath([self.exp_dir, f"*{ext}"])))
             self.microscope_file = (
                 microscope_files[0] if len(microscope_files) > 0 else None
@@ -187,7 +187,7 @@ class ExpDbBatch:
         create_directory(self.raw_path.preprocess_dir)
 
         preprocess_results = preprocessing(
-            microscope=MicroscopeData(self.raw_path.microscope_file),
+            microscope=MicroscopeExpdbData(self.raw_path.microscope_file),
             output_dir=self.raw_path.preprocess_dir,
             params=get_default_params("preprocessing"),
             nwbfile=self.nwb_input_config,

--- a/studio/app/optinist/dataclass/microscope.py
+++ b/studio/app/optinist/dataclass/microscope.py
@@ -12,15 +12,6 @@ class MicroscopeData(BaseData):
         super().__init__(file_name)
         self.path = path
         self.json_path = None
-        self.__data = None
-
-    @property
-    def data(self):
-        return self.__data
-
-    @data.setter
-    def data(self, data):
-        self.__data = data
 
     @property
     def reader(self):
@@ -40,3 +31,6 @@ class MicroscopeData(BaseData):
 
         reader.load(self.path)
         return reader
+
+    def set_data(self, data):
+        self.data = data

--- a/studio/app/optinist/dataclass/microscope_expdb.py
+++ b/studio/app/optinist/dataclass/microscope_expdb.py
@@ -3,4 +3,4 @@ from studio.app.optinist.dataclass.microscope import MicroscopeData
 
 class MicroscopeExpdbData(MicroscopeData):
     def __init__(self, path: str, file_name="microscope_expdb"):
-        super().__init__(file_name)
+        super().__init__(path, file_name)

--- a/studio/app/optinist/dataclass/microscope_expdb.py
+++ b/studio/app/optinist/dataclass/microscope_expdb.py
@@ -1,0 +1,6 @@
+from studio.app.optinist.dataclass.microscope import MicroscopeData
+
+
+class MicroscopeExpdbData(MicroscopeData):
+    def __init__(self, path: str, file_name="microscope_expdb"):
+        super().__init__(file_name)

--- a/studio/app/optinist/wrappers/expdb/preprocessing.py
+++ b/studio/app/optinist/wrappers/expdb/preprocessing.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.dataclass.image import ImageData
-from studio.app.optinist.dataclass.microscope import MicroscopeData
+from studio.app.optinist.dataclass.microscope_expdb import MicroscopeExpdbData
 from studio.app.optinist.microscopes.MicroscopeDataReaderUtils import (
     MicroscopeDataReaderUtils,
 )
@@ -19,7 +19,7 @@ logger = AppLogger.get_logger()
 
 
 def preprocessing(
-    microscope: MicroscopeData, output_dir: str, params: dict = None, **kwargs
+    microscope: MicroscopeExpdbData, output_dir: str, params: dict = None, **kwargs
 ) -> dict(stack=ImageData):
     logger.info("start preprocessing.")
 


### PR DESCRIPTION
### Content

Porting `microscope node` from barebone-studio

### Testcase

- Test environment: Ubuntu docker

#### Scope of this fix

- Workflow
  - [x] microscope
    - microscope -> microscope_to_img -> suite2p_file_convert
  - [x] microscope_database
    - microscope_database -> preprocessing -> suite2p_file_convert
- Batch
  - [x] Analysis batch (run_expdb_batch.py)

- Just to be sure, check that other existing nodes are working
  - [x] tutorial 1
  - [x] tutorial 2
  - [x] tutorial 3
