### PR TITLE
Feature/create cnmf info from mat files fix

### DIFF
--- a/studio/app/common/core/snakemake/smk_utils.py
+++ b/studio/app/common/core/snakemake/smk_utils.py
@@ -164,7 +164,7 @@ class SmkUtils:
 
 
 # Cache conda env path (performance consideration)
-_snakemake_conda_env_paths_cache: Dict[str, str] = {}
+_global_smk_conda_env_paths_cache: Dict[str, str] = {}
 
 
 class SmkInternalUtils:
@@ -238,14 +238,13 @@ class SmkInternalUtils:
               conda_env_dirpath = conda_env.address or ""
               ```
         """
-        global _snakemake_conda_env_paths_cache
-        if conda_env_filepath in _snakemake_conda_env_paths_cache:
-            conda_env_dirpath = _snakemake_conda_env_paths_cache[conda_env_filepath]
+        if conda_env_filepath in _global_smk_conda_env_paths_cache:
+            conda_env_dirpath = _global_smk_conda_env_paths_cache[conda_env_filepath]
         else:
             conda_env_dirpath = cls._get_conda_env_address(
                 conda_env_filepath, conda_env_rootpath
             )
-            _snakemake_conda_env_paths_cache[conda_env_filepath] = conda_env_dirpath
+            _global_smk_conda_env_paths_cache[conda_env_filepath] = conda_env_dirpath
 
         """
         Verify that conda env has been created by snakemake

--- a/studio/app/common/dataclass/utils.py
+++ b/studio/app/common/dataclass/utils.py
@@ -27,5 +27,5 @@ def save_thumbnail(plot_file):
         new_width = int(w * (THUMBNAIL_HEIGHT / h))
         # LANCZOS is high-quality downsampling filter
         # BILINEAR is faster
-        thumb_img = img.resize((new_width, THUMBNAIL_HEIGHT), Image.Resampling.BILINEAR)
+        thumb_img = img.resize((new_width, THUMBNAIL_HEIGHT), Image.Resampling.BICUBIC)
         thumb_img.save(plot_file.replace(".png", ".thumb.png"))

--- a/studio/app/optinist/core/expdb/batch_runner.py
+++ b/studio/app/optinist/core/expdb/batch_runner.py
@@ -279,20 +279,17 @@ class ExpDbBatchRunner:
                 self.logger_.warning(
                     "No microscope data found. Will use existing processed data."
                 )
-                cnmf_info = expdb_batch.create_cnmf_info_from_mat_files()
             else:
                 stack = expdb_batch.preprocess()
                 expdb_batch.generate_orimaps(stack)
-                cnmf_info = expdb_batch.cell_detection_cnmf(stack)
+                expdb_batch.cell_detection_cnmf(stack)
                 del stack
 
             stat_data = expdb_batch.generate_statdata()
             expdb_batch.generate_cellmasks()
             expdb_batch.generate_pixelmaps()
             expdb_batch.generate_plots(stat_data=stat_data)
-            expdb_batch.generate_plots_using_cnmf_info(
-                stat_data=stat_data, cnmf_info=cnmf_info
-            )
+            expdb_batch.generate_plots_spatial(stat_data=stat_data)
 
             # Read metadata
             (attributes, view_attributes) = expdb_batch.load_exp_metadata()

--- a/studio/app/optinist/core/expdb/batch_unit.py
+++ b/studio/app/optinist/core/expdb/batch_unit.py
@@ -83,7 +83,7 @@ def save_image_with_thumb(img_path: str, img):
     img.save(img_path)
     w, h = img.size
     new_width = int(w * (THUMBNAIL_HEIGHT / h))
-    thumb_img = img.resize((new_width, THUMBNAIL_HEIGHT), Image.Resampling.BILINEAR)
+    thumb_img = img.resize((new_width, THUMBNAIL_HEIGHT), Image.Resampling.BICUBIC)
     thumb_img.save(img_path.replace(".png", ".thumb.png"))
 
 

--- a/studio/app/optinist/core/expdb/batch_unit.py
+++ b/studio/app/optinist/core/expdb/batch_unit.py
@@ -207,6 +207,7 @@ class ExpDbBatch:
     def process_roi_masks(self):
         """
         Process cellmask data  from .mat file to create ROI image.
+        Uses cnmf.get_roi function that is used in creating cnmf_info.
         Returns roi_image : ndarray
             2D composite ROI mask
         """

--- a/studio/app/optinist/wrappers/expdb/kmeans_analysis.py
+++ b/studio/app/optinist/wrappers/expdb/kmeans_analysis.py
@@ -30,7 +30,8 @@ def kmeans_analysis(
     ----------
     stat : StatData
         StatData object to store analysis results
-    roi_masks data: np.ndarray
+    roi_masks : ndarray
+        ROI masks data
     output_dir : str
         Directory for saving output files
     params : dict, optional
@@ -353,8 +354,8 @@ def generate_kmeans_visualization(
         Dictionary of sorted correlation matrices for each k value
     fluorescence : ndarray
         Temporal components/fluorescence traces (n_rois x time)
-    roi_masks : ndarray or None
-        ROI masks data in any format
+    roi_masks : ndarray
+        ROI masks data
     silhouette_scores : ndarray, optional
         Silhouette scores for different numbers of clusters
     optimal_clusters : int, optional

--- a/studio/app/optinist/wrappers/expdb/pca_analysis.py
+++ b/studio/app/optinist/wrappers/expdb/pca_analysis.py
@@ -28,7 +28,8 @@ def pca_analysis(
     ----------
     stat : StatData
         StatData object to store analysis results
-    roi_masks data: np.ndarray
+    roi_masks : ndarray
+        ROI masks data
     fluorescence data: np.ndarray
         Fluorescence data matrix (rois x time)
     output_dir : str

--- a/studio/app/optinist/wrappers/expdb/pca_analysis.py
+++ b/studio/app/optinist/wrappers/expdb/pca_analysis.py
@@ -14,7 +14,8 @@ logger = AppLogger.get_logger()
 
 def pca_analysis(
     stat: StatData,
-    cnmf_info: dict,
+    roi_masks: np.ndarray,
+    fluorescence: np.ndarray,
     output_dir: str,
     params: dict = None,
     ts_file=None,
@@ -27,8 +28,9 @@ def pca_analysis(
     ----------
     stat : StatData
         StatData object to store analysis results
-    cnmf_info : dict
-        Dictionary containing CNMF results including fluorescence data
+    roi_masks data: np.ndarray
+    fluorescence data: np.ndarray
+        Fluorescence data matrix (cells x time)
     output_dir : str
         Directory for saving output files
     params : dict, optional
@@ -45,7 +47,6 @@ def pca_analysis(
     """
 
     # Get the fluorescence data
-    fluorescence = cnmf_info["fluorescence"].data
     n_cells = fluorescence.shape[0]
 
     # # If iscell data is available, use it to filter fluorescence
@@ -81,7 +82,7 @@ def pca_analysis(
         stat.pca_explained_variance = dummy_explained_variance
 
         # Store ROI masks for visualization
-        stat.roi_masks = cnmf_info["all_roi"].data
+        stat.roi_masks = roi_masks
 
         # Still create visualization objects for proper UI display
         stat.set_pca_props()
@@ -226,7 +227,7 @@ def pca_analysis(
 
     # Store ROI masks for visualization
     # Request from client to use data not filtered by iscell
-    stat.roi_masks = cnmf_info["all_roi"].data
+    stat.roi_masks = roi_masks
 
     # Create visualization objects within the function
     stat.set_pca_props()


### PR DESCRIPTION
Fix for https://github.com/arayabrain/optinist-for-server/issues/388

**Problem:**
Generating plots from microscope data, compared to generating from saved mat files produced different results. 

**Cause:**
Needed to apply identical processing to spatial components from both raw CNMF output and loaded MAT files
The raw pipeline separates data into idx_good/idx_bad before combining in cnmf_info
MAT files don't contain idx_good separation, making consistency difficult

**Solution:**
Realized idx_good filtering isn't actually necessary for our purposes
Switched to exclusively using MAT files from cell_detection_cnmf
Created a new function (generate_plots_spatial) that:


Now we use load_raw_cellmask_data and load_raw_timecourse_data
Perform get_roi() processing directly on this data
Bypasses the need to import cnmf_info


**Testing:**
Copy and rename M000000_ori001 to M000000_ori002
```
echo "command: regist" > /app/experiments_datasets/M000000/M000000_ori001.proc
echo "command: regist" > /app/experiments_datasets/M000000/M000000_ori002.proc
python run_expdb_batch.py -o 1 
```
Then delete M000000_ori002.nd2 file
`echo "command: regist" > /app/experiments_datasets/M000000/M000000_ori002.proc`

Top row is microscope data, bottom is mat file
<img width="1143" alt="image" src="https://github.com/user-attachments/assets/a586f61c-c0a8-42a7-8a67-c09acef8625c" />


Main changed functions:
```
process_roi_masks
generate_plots_spatial
```