### PR TITLE
Avoiding pip install errors in a dockerfile

### DIFF
--- a/studio/config/docker/Dockerfile
+++ b/studio/config/docker/Dockerfile
@@ -85,7 +85,7 @@ RUN pip3 install --no-cache-dir --upgrade pip && \
 RUN poetry export -f requirements.txt -o requirements.studio.txt && \
     sed -e '/^h5py/d' requirements.studio.txt > requirements.batch.txt
 
-RUN pip3 install -r requirements.studio.txt
+RUN pip3 install -r requirements.studio.txt --use-pep517
 
 # Setting permissions for operational user to some site-packages.
 RUN chown -R optinist /usr/local/lib/python3.9/site-packages/pynwb
@@ -104,7 +104,7 @@ USER optinist
 RUN . ~/.bashrc && \
     conda activate expdb_batch && \
     pip3 install --no-cache-dir --upgrade pip && \
-    pip3 install -r requirements.batch.txt
+    pip3 install -r requirements.batch.txt --use-pep517
 
 # Some environment variable settings
 # - Settings for protobuf 3.20 compatibility

--- a/studio/config/docker/Dockerfile.dev
+++ b/studio/config/docker/Dockerfile.dev
@@ -85,7 +85,7 @@ RUN pip3 install --no-cache-dir --upgrade pip && \
 RUN poetry export -f requirements.txt -o requirements.studio.txt && \
     sed -e '/^h5py/d' requirements.studio.txt > requirements.batch.txt
 
-RUN pip3 install -r requirements.studio.txt
+RUN pip3 install -r requirements.studio.txt --use-pep517
 
 # Setting permissions for operational user to some site-packages.
 RUN chown -R optinist /usr/local/lib/python3.9/site-packages/pynwb
@@ -104,7 +104,7 @@ USER optinist
 RUN . ~/.bashrc && \
     conda activate expdb_batch && \
     pip3 install --no-cache-dir --upgrade pip && \
-    pip3 install -r requirements.batch.txt
+    pip3 install -r requirements.batch.txt --use-pep517
 
 # Some environment variable settings
 # - Settings for protobuf 3.20 compatibility


### PR DESCRIPTION
### Content

In the Dockerfile, there is a part where pip install is executed using the requirements.txt exported from poetry, but the following error occurs in that part. This PR addresses this error.

#### Error log

```
Collecting lauda==1.2.0 (from -r requirements.batch.txt (line 835))
  Downloading lauda-1.2.0.tar.gz (2.0 kB)
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [41 lines of output]
      /home/optinist/.conda/envs/expdb_batch/lib/python3.9/site-packages/setuptools/__init__.py:92: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated.
      !!
      
              ********************************************************************************
              Requirements should be satisfied by a PEP 517 installer.
              If you are using pip, you can try `pip install --use-pep517`.
      
              By 2025-Oct-31, you need to update your project and remove deprecated calls
              or your builds will no longer be supported.
              ********************************************************************************
      
      !!
        dist.fetch_build_eggs(dist.setup_requires)
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 35, in <module>
        File "/tmp/pip-install-kxlhnp70/lauda_b991b92141654d04bd16590f549de552/setup.py", line 23, in <module>
          setup(
        File "/home/optinist/.conda/envs/expdb_batch/lib/python3.9/site-packages/setuptools/__init__.py", line 114, in setup
          _install_setup_requires(attrs)
        File "/home/optinist/.conda/envs/expdb_batch/lib/python3.9/site-packages/setuptools/__init__.py", line 87, in _install_setup_requires
          _fetch_build_eggs(dist)
        File "/home/optinist/.conda/envs/expdb_batch/lib/python3.9/site-packages/setuptools/__init__.py", line 92, in _fetch_build_eggs
          dist.fetch_build_eggs(dist.setup_requires)
        File "/home/optinist/.conda/envs/expdb_batch/lib/python3.9/site-packages/setuptools/dist.py", line 766, in fetch_build_eggs
          return _fetch_build_eggs(self, requires)
        File "/home/optinist/.conda/envs/expdb_batch/lib/python3.9/site-packages/setuptools/installer.py", line 54, in _fetch_build_eggs
          resolved_dists = [_fetch_build_egg_no_warn(dist, req) for req in needed_reqs]
        File "/home/optinist/.conda/envs/expdb_batch/lib/python3.9/site-packages/setuptools/installer.py", line 54, in <listcomp>
          resolved_dists = [_fetch_build_egg_no_warn(dist, req) for req in needed_reqs]
        File "/home/optinist/.conda/envs/expdb_batch/lib/python3.9/site-packages/setuptools/installer.py", line 51, in <genexpr>
          needed_reqs = (
        File "/home/optinist/.conda/envs/expdb_batch/lib/python3.9/site-packages/setuptools/installer.py", line 40, in _present
          return any(_dist_matches_req(dist, req) for dist in metadata.distributions())
        File "/home/optinist/.conda/envs/expdb_batch/lib/python3.9/site-packages/setuptools/installer.py", line 40, in <genexpr>
          return any(_dist_matches_req(dist, req) for dist in metadata.distributions())
        File "/home/optinist/.conda/envs/expdb_batch/lib/python3.9/site-packages/setuptools/installer.py", line 64, in _dist_matches_req
          packaging.utils.canonicalize_name(egg_dist.name)
        File "/home/optinist/.conda/envs/expdb_batch/lib/python3.9/site-packages/importlib_metadata/__init__.py", line 547, in name
          return md_none(self.metadata)['Name']
      TypeError: 'NoneType' object is not subscriptable
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.
```
#### Countermeasure

Add the option `--use-pep517` to pip install.
*However, since this error is caused by installing an old module, it may be necessary to consider switching the module used in the future.

### Test case

- Same as the test case of below:
  - arayabrain/barebone-studio#944
