### PR TITLE
[Refactoring] Added expdb id and path parser

### DIFF
--- a/studio/app/common/core/rules/file_writer.py
+++ b/studio/app/common/core/rules/file_writer.py
@@ -1,14 +1,11 @@
 import json
-import os
 
 import h5py
 
 from studio.app.common.core.snakemake.smk import Rule
-from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.common.dataclass import CsvData, ImageData, TimeSeriesData
 from studio.app.const import EXP_METADATA_SUFFIX, FILETYPE
-from studio.app.expdb_dir_path import EXPDB_DIRPATH
-from studio.app.optinist.core.expdb.expdb_data import ExpDbPathIds
+from studio.app.optinist.core.expdb.expdb_data import ExpDbPathIds, ExpDbPathIdsUtil
 from studio.app.optinist.core.nwb.nwb import NWBDATASET
 from studio.app.optinist.dataclass.expdb import ExpDbData
 from studio.app.optinist.dataclass.iscell import IscellData
@@ -135,14 +132,8 @@ class FileWriter:
 
     @classmethod
     def get_experiment_metadata(cls, exp_id) -> dict:
-        subject_id = ExpDbPathIds(exp_id=exp_id).subject_id
-        metadata_path = join_filepath(
-            [
-                EXPDB_DIRPATH.EXPDB_DIR,
-                subject_id,
-                exp_id,
-                f"{exp_id}_{EXP_METADATA_SUFFIX}.json",
-            ]
+        metadata_path = ExpDbPathIdsUtil.create_expdb_file_path(
+            exp_id, f"{exp_id}_{EXP_METADATA_SUFFIX}.json"
         )
 
         with open(metadata_path) as f:

--- a/studio/app/common/core/rules/file_writer.py
+++ b/studio/app/common/core/rules/file_writer.py
@@ -8,6 +8,7 @@ from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.common.dataclass import CsvData, ImageData, TimeSeriesData
 from studio.app.const import EXP_METADATA_SUFFIX, FILETYPE
 from studio.app.expdb_dir_path import EXPDB_DIRPATH
+from studio.app.optinist.core.expdb.expdb_data import ExpDbPathIds
 from studio.app.optinist.core.nwb.nwb import NWBDATASET
 from studio.app.optinist.dataclass.expdb import ExpDbData
 from studio.app.optinist.dataclass.iscell import IscellData
@@ -80,7 +81,7 @@ class FileWriter:
         nwbfile = rule_config.nwbfile
         nwbfile["image_series"]["external_file"] = info[rule_config.return_arg]
 
-        exp_id = os.path.basename(os.path.dirname(rule_config.input))
+        exp_id = ExpDbPathIds(expdb_path=rule_config.input).exp_id
         metadata = cls.get_experiment_metadata(exp_id)
         nwbfile[NWBDATASET.LAB_METADATA] = metadata
 
@@ -125,7 +126,7 @@ class FileWriter:
         nwbfile = rule_config.nwbfile
         nwbfile["image_series"]["external_file"] = info[rule_config.return_arg]
 
-        exp_id = os.path.basename(os.path.dirname(rule_config.input[0]))
+        exp_id = ExpDbPathIds(expdb_path=rule_config.input[0]).exp_id
         metadata = cls.get_experiment_metadata(exp_id)
         nwbfile[NWBDATASET.LAB_METADATA] = metadata
 
@@ -134,7 +135,7 @@ class FileWriter:
 
     @classmethod
     def get_experiment_metadata(cls, exp_id) -> dict:
-        subject_id = exp_id.split("_")[0]
+        subject_id = ExpDbPathIds(exp_id=exp_id).subject_id
         metadata_path = join_filepath(
             [
                 EXPDB_DIRPATH.EXPDB_DIR,

--- a/studio/app/common/core/snakemake/smk_utils.py
+++ b/studio/app/common/core/snakemake/smk_utils.py
@@ -16,8 +16,7 @@ from studio.app.common.core.utils.filepath_finder import find_condaenv_filepath
 from studio.app.common.core.workflow.workflow import NodeType, NodeTypeUtil
 from studio.app.const import ACCEPT_FILE_EXT, FILETYPE, TC_SUFFIX, TS_SUFFIX
 from studio.app.dir_path import DIRPATH
-from studio.app.expdb_dir_path import EXPDB_DIRPATH
-from studio.app.optinist.core.expdb.expdb_data import ExpDbPathIds
+from studio.app.optinist.core.expdb.expdb_data import ExpDbPathIdsUtil
 from studio.app.wrappers import wrapper_dict
 
 logger = AppLogger.get_logger()
@@ -31,9 +30,7 @@ class SmkUtils:
                 return [join_filepath([DIRPATH.INPUT_DIR, x]) for x in details["input"]]
             elif details["type"] == FILETYPE.MICROSCOPE_EXPDB:
                 exp_id = details["input"]
-                subject_id = ExpDbPathIds(exp_id=exp_id).subject_id
-                exp_dir = join_filepath([EXPDB_DIRPATH.EXPDB_DIR, subject_id, exp_id])
-
+                exp_dir = ExpDbPathIdsUtil.create_expdb_file_path(exp_id, "")
                 microscope_files = []
                 for ext in ACCEPT_FILE_EXT.MICROSCOPE_EXPDB_EXT.value:
                     microscope_files.extend(glob(join_filepath([exp_dir, f"*{ext}"])))
@@ -47,24 +44,12 @@ class SmkUtils:
                 return microscope_files
             elif details["type"] == FILETYPE.EXPDB:
                 exp_id = details["input"]
-                subject_id = ExpDbPathIds(exp_id=exp_id).subject_id
                 return [
-                    join_filepath(
-                        [
-                            EXPDB_DIRPATH.EXPDB_DIR,
-                            subject_id,
-                            exp_id,
-                            f"{exp_id}_{TS_SUFFIX}.mat",
-                        ]
+                    ExpDbPathIdsUtil.create_expdb_file_path(
+                        exp_id, f"{exp_id}_{TS_SUFFIX}.mat"
                     ),
-                    join_filepath(
-                        [
-                            EXPDB_DIRPATH.EXPDB_DIR,
-                            subject_id,
-                            exp_id,
-                            "preprocess",
-                            f"{exp_id}_{TC_SUFFIX}.mat",
-                        ]
+                    ExpDbPathIdsUtil.create_expdb_file_path(
+                        exp_id, f"{exp_id}_{TC_SUFFIX}.mat", ["preprocess"]
                     ),
                 ]
             else:

--- a/studio/app/common/core/snakemake/smk_utils.py
+++ b/studio/app/common/core/snakemake/smk_utils.py
@@ -17,6 +17,7 @@ from studio.app.common.core.workflow.workflow import NodeType, NodeTypeUtil
 from studio.app.const import ACCEPT_FILE_EXT, FILETYPE, TC_SUFFIX, TS_SUFFIX
 from studio.app.dir_path import DIRPATH
 from studio.app.expdb_dir_path import EXPDB_DIRPATH
+from studio.app.optinist.core.expdb.expdb_data import ExpDbPathIds
 from studio.app.wrappers import wrapper_dict
 
 logger = AppLogger.get_logger()
@@ -30,7 +31,7 @@ class SmkUtils:
                 return [join_filepath([DIRPATH.INPUT_DIR, x]) for x in details["input"]]
             elif details["type"] == FILETYPE.MICROSCOPE_EXPDB:
                 exp_id = details["input"]
-                subject_id = exp_id.split("_")[0]
+                subject_id = ExpDbPathIds(exp_id=exp_id).subject_id
                 exp_dir = join_filepath([EXPDB_DIRPATH.EXPDB_DIR, subject_id, exp_id])
 
                 microscope_files = []
@@ -46,7 +47,7 @@ class SmkUtils:
                 return microscope_files
             elif details["type"] == FILETYPE.EXPDB:
                 exp_id = details["input"]
-                subject_id = exp_id.split("_")[0]
+                subject_id = ExpDbPathIds(exp_id=exp_id).subject_id
                 return [
                     join_filepath(
                         [

--- a/studio/app/optinist/core/expdb/batch_unit.py
+++ b/studio/app/optinist/core/expdb/batch_unit.py
@@ -42,6 +42,7 @@ from studio.app.optinist.core.expdb.crud_expdb import (
     extract_experiment_view_attributes,
     get_experiment,
 )
+from studio.app.optinist.core.expdb.expdb_data import ExpDbPathIds
 from studio.app.optinist.core.nwb.nwb import NWBDATASET
 from studio.app.optinist.core.nwb.nwb_creater import merge_nwbfile, save_nwb
 from studio.app.optinist.dataclass import ExpDbData, StatData
@@ -87,9 +88,9 @@ def save_image_with_thumb(img_path: str, img):
     thumb_img.save(img_path.replace(".png", ".thumb.png"))
 
 
-class ExpDbPath:
+class ExpDbBatchPath:
     def __init__(self, exp_id: str, is_raw=False):
-        subject_id = exp_id.split("_")[0]
+        subject_id = ExpDbPathIds(exp_id=exp_id).subject_id
 
         if is_raw:
             self.exp_dir = join_filepath([EXPDB_DIRPATH.EXPDB_DIR, subject_id, exp_id])
@@ -148,8 +149,8 @@ class ExpDbBatch:
         self.exp_id = exp_id
         self.org_id = org_id
 
-        self.raw_path = ExpDbPath(self.exp_id, is_raw=True)
-        self.pub_path = ExpDbPath(self.exp_id)
+        self.raw_path = ExpDbBatchPath(self.exp_id, is_raw=True)
+        self.pub_path = ExpDbBatchPath(self.exp_id)
         self.nwb_input_config = ConfigReader.read(find_param_filepath("nwb"))
         self.nwbfile = {}
         self._configure_matplotlib()

--- a/studio/app/optinist/core/expdb/batch_unit.py
+++ b/studio/app/optinist/core/expdb/batch_unit.py
@@ -35,14 +35,13 @@ from studio.app.const import (
     THUMBNAIL_HEIGHT,
     TS_SUFFIX,
 )
-from studio.app.expdb_dir_path import EXPDB_DIRPATH
 from studio.app.optinist.core.expdb.crud_cells import bulk_delete_cells
 from studio.app.optinist.core.expdb.crud_expdb import (
     delete_experiment,
     extract_experiment_view_attributes,
     get_experiment,
 )
-from studio.app.optinist.core.expdb.expdb_data import ExpDbPathIds
+from studio.app.optinist.core.expdb.expdb_data import ExpDbPathIdsUtil
 from studio.app.optinist.core.nwb.nwb import NWBDATASET
 from studio.app.optinist.core.nwb.nwb_creater import merge_nwbfile, save_nwb
 from studio.app.optinist.dataclass import ExpDbData, StatData
@@ -90,10 +89,8 @@ def save_image_with_thumb(img_path: str, img):
 
 class ExpDbBatchPath:
     def __init__(self, exp_id: str, is_raw=False):
-        subject_id = ExpDbPathIds(exp_id=exp_id).subject_id
-
         if is_raw:
-            self.exp_dir = join_filepath([EXPDB_DIRPATH.EXPDB_DIR, subject_id, exp_id])
+            self.exp_dir = ExpDbPathIdsUtil.create_expdb_file_path(exp_id, "")
             assert os.path.exists(self.exp_dir), f"exp_dir not found: {self.exp_dir}"
             self.output_dir = join_filepath([self.exp_dir, "outputs"])
 
@@ -127,9 +124,7 @@ class ExpDbBatchPath:
                 [self.preprocess_dir, f"{exp_id}_{CELLMASK_SUFFIX}.mat"]
             )
         else:
-            self.exp_dir = join_filepath(
-                [EXPDB_DIRPATH.PUBLIC_EXPDB_DIR, subject_id, exp_id]
-            )
+            self.exp_dir = ExpDbPathIdsUtil.create_public_expdb_file_path(exp_id, "")
             self.output_dir = self.exp_dir
 
         # outputs

--- a/studio/app/optinist/core/expdb/expdb_data.py
+++ b/studio/app/optinist/core/expdb/expdb_data.py
@@ -1,0 +1,69 @@
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from studio.app.expdb_dir_path import EXPDB_DIRPATH
+
+
+@dataclass
+class ExpDbPathIds:
+    ID_DELIMITER = "_"
+
+    expdb_path: Optional[str] = None
+    exp_id: Optional[str] = None
+    subject_id: Optional[str] = None
+    exp_sub_number: Optional[str] = None
+
+    def __post_init__(self):
+        """
+        Extract each ID from expdb data_path
+        - data_path format
+          - {EXPDB_DIRPATH.EXPDB_DIR}/{subject_id}/{exp_id}
+        - exp_id format
+          - {subject_id}/{exp_sub_number}
+        """
+
+        # Parse data_path
+        if self.expdb_path:
+            data_relative_dir = os.path.relpath(
+                self.expdb_path.replace("\\", "/"),
+                EXPDB_DIRPATH.EXPDB_DIR.replace("\\", "/"),
+            ).replace("\\", "/")
+            splitted_ids = data_relative_dir.split("/")
+
+            ids_count = len(splitted_ids)
+
+            if ids_count == 2:
+                self.subject_id, self.exp_id = splitted_ids
+            elif ids_count == 3:
+                self.subject_id, self.exp_id, _ = splitted_ids
+            else:
+                assert False, (
+                    "Invalid expdb path specified: "
+                    f"[ids_count: {ids_count}] [path: {data_relative_dir}]"
+                )
+
+        # Parse exp_id
+        if self.subject_id is None or self.exp_sub_number is None and self.exp_id:
+            exp_id_elements = self.exp_id.split(__class__.ID_DELIMITER)
+            if len(exp_id_elements) != 2:
+                assert False, f"Invalid exp_id format: [exp_id: {self.exp_id}]"
+
+            self.subject_id, self.exp_sub_number = exp_id_elements
+
+
+class ExpDbPathIdsUtil:
+    @staticmethod
+    def parse_ids_from_workflow_output_path(output_path: str) -> ExpDbPathIds:
+        """
+        A utility to extract exp_ids from the output of a workflow
+          that uses expdb as input data.
+
+        - Workflow output path example
+          - {DIRPATH.OUTPUT_DIR}/1/xxxxxxxx/preprocessing_yyyyyyyyyy/tiff \
+            /M000000_ori001_avg_ch1/M000000_ori001_avg_ch1.tif"
+        """
+        exp_id = ExpDbPathIds.ID_DELIMITER.join(
+            os.path.basename(output_path).split(ExpDbPathIds.ID_DELIMITER)[:2]
+        )
+        return ExpDbPathIds(exp_id=exp_id)

--- a/studio/app/optinist/core/expdb/expdb_data.py
+++ b/studio/app/optinist/core/expdb/expdb_data.py
@@ -1,7 +1,8 @@
 import os
 from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional
 
+from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.expdb_dir_path import EXPDB_DIRPATH
 
 
@@ -53,6 +54,40 @@ class ExpDbPathIds:
 
 
 class ExpDbPathIdsUtil:
+    @classmethod
+    def __create_expdb_file_path(
+        cls, root_dir: str, exp_id: str, file_name: str, subdir: List[str] = []
+    ) -> str:
+        exp_ids = ExpDbPathIds(exp_id=exp_id)
+
+        path = join_filepath(
+            [
+                root_dir,
+                exp_ids.subject_id,
+                exp_id,
+                *subdir,
+                file_name,
+            ]
+        )
+
+        return path
+
+    @classmethod
+    def create_expdb_file_path(
+        cls, exp_id: str, file_name: str, subdir: List[str] = []
+    ) -> str:
+        return cls.__create_expdb_file_path(
+            EXPDB_DIRPATH.EXPDB_DIR, exp_id, file_name, subdir
+        )
+
+    @classmethod
+    def create_public_expdb_file_path(
+        cls, exp_id: str, file_name: str, subdir: List[str] = []
+    ) -> str:
+        return cls.__create_expdb_file_path(
+            EXPDB_DIRPATH.PUBLIC_EXPDB_DIR, exp_id, file_name, subdir
+        )
+
     @staticmethod
     def parse_ids_from_workflow_output_path(output_path: str) -> ExpDbPathIds:
         """

--- a/studio/app/optinist/routers/expdb.py
+++ b/studio/app/optinist/routers/expdb.py
@@ -22,6 +22,7 @@ from studio.app.common.schemas.users import User
 from studio.app.expdb_dir_path import EXPDB_DIRPATH
 from studio.app.optinist import models as optinist_model
 from studio.app.optinist.core.expdb.crud_expdb import extract_experiment_view_attributes
+from studio.app.optinist.core.expdb.expdb_data import ExpDbPathIds
 from studio.app.optinist.schemas.base import SortDirection, SortOptions
 from studio.app.optinist.schemas.expdb.cell import ExpDbCell
 from studio.app.optinist.schemas.expdb.config import ExpDbExperimentFilterParams
@@ -90,7 +91,7 @@ def expdbcell_transformer(items: Sequence) -> Sequence:
 
     for item in items:
         expdbcell = ExpDbCell.from_orm(item)
-        subject_id = expdbcell.experiment_id.split("_")[0]
+        subject_id = ExpDbPathIds(exp_id=expdbcell.experiment_id).subject_id
         exp_dir = f"{EXPDB_DIRPATH.GRAPH_HOST}/{subject_id}/{expdbcell.experiment_id}"
         try:
             expdbcell.fields = ExpDbExperimentFields(**item.view_attributes)
@@ -113,7 +114,7 @@ def experiment_transformer(items: Sequence) -> Sequence:
     for item in items:
         expdb: optinist_model.Experiment = item
         exp = ExpDbExperiment.from_orm(expdb)
-        subject_id = exp.experiment_id.split("_")[0]
+        subject_id = ExpDbPathIds(exp_id=exp.experiment_id).subject_id
         exp_dir = f"{EXPDB_DIRPATH.GRAPH_HOST}/{subject_id}/{exp.experiment_id}"
 
         try:

--- a/studio/app/optinist/wrappers/caiman/cnmf_preprocessing.py
+++ b/studio/app/optinist/wrappers/caiman/cnmf_preprocessing.py
@@ -8,6 +8,7 @@ from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.common.dataclass import ImageData
 from studio.app.const import CELLMASK_SUFFIX, TC_SUFFIX, TS_SUFFIX
+from studio.app.optinist.core.expdb.expdb_data import ExpDbPathIdsUtil
 from studio.app.optinist.core.nwb.nwb import NWBDATASET
 from studio.app.optinist.dataclass import EditRoiData, FluoData, IscellData, RoiData
 from studio.app.optinist.dataclass.expdb import ExpDbData
@@ -104,7 +105,8 @@ def caiman_cnmf_preprocessing(
     if isinstance(file_path, list):
         file_path = file_path[0]
 
-    exp_id = "_".join(os.path.basename(file_path).split("_")[:2])
+    exp_ids = ExpDbPathIdsUtil.parse_ids_from_workflow_output_path(file_path)
+    exp_id = exp_ids.exp_id
 
     images = images.data
     mmap_paths = []

--- a/studio/app/optinist/wrappers/caiman/cnmf_preprocessing.py
+++ b/studio/app/optinist/wrappers/caiman/cnmf_preprocessing.py
@@ -1,5 +1,4 @@
 import gc
-import os
 
 import numpy as np
 import scipy
@@ -82,8 +81,6 @@ def caiman_cnmf_preprocessing(
     from caiman.cluster import setup_cluster
     from caiman.source_extraction.cnmf import cnmf, online_cnmf
     from caiman.source_extraction.cnmf.params import CNMFParams
-
-    from studio.app.expdb_dir_path import EXPDB_DIRPATH
 
     function_id = "caiman_cnmf"
     logger.info(f"start {function_id}")
@@ -179,14 +176,11 @@ def caiman_cnmf_preprocessing(
 
     AY = calculate_AY(cnm.estimates.A, cnm.estimates.C, Yr, dims)
     timecourse_path = join_filepath([output_dir, f"{exp_id}_{TC_SUFFIX}.mat"])
-    trialstructure_path = join_filepath(
-        [
-            EXPDB_DIRPATH.EXPDB_DIR,
-            exp_id.split("_")[0],
-            exp_id,
-            f"{exp_id}_{TS_SUFFIX}.mat",
-        ]
+    trialstructure_path = ExpDbPathIdsUtil.create_expdb_file_path(
+        exp_id,
+        f"{exp_id}_{TS_SUFFIX}.mat",
     )
+
     scipy.io.savemat(timecourse_path, {"timecourse": AY})
 
     scipy.io.savemat(

--- a/studio/app/optinist/wrappers/expdb/preprocessing.py
+++ b/studio/app/optinist/wrappers/expdb/preprocessing.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.dataclass.image import ImageData
+from studio.app.optinist.core.expdb.expdb_data import ExpDbPathIds
 from studio.app.optinist.dataclass.microscope_expdb import MicroscopeExpdbData
 from studio.app.optinist.microscopes.MicroscopeDataReaderUtils import (
     MicroscopeDataReaderUtils,
@@ -29,7 +30,7 @@ def preprocessing(
         params_flatten.update(segment)
     params = params_flatten
 
-    exp_id = os.path.basename(os.path.dirname(microscope.path))
+    exp_id = ExpDbPathIds(expdb_path=microscope.path).exp_id
     reader = MicroscopeDataReaderUtils.get_reader(microscope.path)
     ome_meta = reader.ome_metadata
 

--- a/studio/app/optinist/wrappers/expdb/preprocessing.py
+++ b/studio/app/optinist/wrappers/expdb/preprocessing.py
@@ -1,5 +1,3 @@
-import os
-
 import numpy as np
 
 from studio.app.common.core.logger import AppLogger


### PR DESCRIPTION
### Content

The parsing and generation processes for path and id related to expdb were hard coded in various places, so I made them common functions and organized them.

- Added expdb id related parse module (791864b)
- Added function to generate data path from exp_id (2f7143f)

### Testcase

Verify that each of the following processes can be performed correctly
and that data is output correctly (the same results as before the correction).

- GUI Workflow Run
  - [x] microscope_expdb -> preprocessing
  - [x] preprocessed_data -> analyze_stats

- Analysis Batch Run (run_expdb_batch.py)
  - [x] preprocessing -> caiman_cnmf_preprocessing

- Site
  - [x] Public Experiments ... Image Display
  - [x] Public Cells Image ... Image Display