### PR TITLE
Analysis batch GUI execution (2nd commit)

### DIFF
--- a/frontend/src/store/slice/Pipeline/PipelineHook.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineHook.ts
@@ -27,7 +27,10 @@ import {
   selectPipelineIsExpdbBatchRun,
 } from "store/slice/Pipeline/PipelineSelectors"
 import { RUN_STATUS } from "store/slice/Pipeline/PipelineType"
-import { handleWorkflowYamlError } from "store/slice/Pipeline/PipelineUtils"
+import {
+  handleExpDbBatchWorkflowError,
+  handleWorkflowYamlError,
+} from "store/slice/Pipeline/PipelineUtils"
 import { selectRunPostData } from "store/slice/Run/RunSelectors"
 import { selectModeStandalone } from "store/slice/Standalone/StandaloneSeclector"
 import {
@@ -142,7 +145,7 @@ export function useRunPipeline() {
       )
         .unwrap()
         .catch((error) => {
-          handleWorkflowYamlError(error, enqueueSnackbar)
+          handleExpDbBatchWorkflowError(error, enqueueSnackbar)
         })
     },
     [dispatch, enqueueSnackbar, prepareRunPostData],

--- a/frontend/src/store/slice/Pipeline/PipelineUtils.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineUtils.ts
@@ -143,3 +143,21 @@ export function handleWorkflowYamlError(
     enqueueSnackbar("Failed to Run workflow", { variant: "error" })
   }
 }
+
+export function handleExpDbBatchWorkflowError(
+  error: ApiError,
+  enqueueSnackbar: (message: string, options?: OptionsObject) => SnackbarKey,
+): void {
+  // Catch workflow yaml parameter errors
+  if (error?.response?.status === 422) {
+    const snackbarOptions: OptionsObject = {
+      variant: "warning",
+    }
+    enqueueSnackbar(
+      "An error occurred while run Analys Batch. Please check the log for details.",
+      snackbarOptions,
+    )
+  } else {
+    enqueueSnackbar("Failed to Run workflow", { variant: "error" })
+  }
+}

--- a/studio/app/common/core/workflow/workflow_reader.py
+++ b/studio/app/common/core/workflow/workflow_reader.py
@@ -1,5 +1,6 @@
 import os
-from typing import Dict
+import re
+from typing import Dict, List
 
 from studio.app.common.core.experiment.experiment import ExptOutputPathIds
 from studio.app.common.core.utils.config_handler import ConfigReader
@@ -9,6 +10,7 @@ from studio.app.common.core.workflow.workflow import (
     Node,
     NodeData,
     NodePosition,
+    NodeType,
     Style,
 )
 from studio.app.common.schemas.workflow import WorkflowConfig
@@ -85,3 +87,49 @@ class WorkflowConfigReader:
             )
             for key, value in config.items()
         }
+
+    @staticmethod
+    def find_node_in_workflow(config: WorkflowConfig, node_name: str) -> Node:
+        """
+        Find the specified node in the WorkflowConfig
+
+        - Notes:
+          - The property to be compared changes depending on the type of node.
+            (Data node or Algo node. following the specifications of workflow.yaml)
+          - If there are multiple nodes with the same name, return the first one.
+        """
+        matched_node: Node = None
+
+        for _, node in config.nodeDict.items():
+            # NOTE: Switching the property to compare by node type
+            checking_node_name = (
+                node.data.path if node.type == NodeType.ALGO else node.data.fileType
+            )
+
+            if re.search(rf"\b{node_name}$", checking_node_name):
+                matched_node = node
+                break
+
+        return matched_node
+
+    @staticmethod
+    def extract_node_names_in_workflow(config: WorkflowConfig) -> List[str]:
+        """
+        Extract each node names contained in the WorkflowConfig
+
+        - Notes:
+          - The property to be compared changes depending on the type of node.
+            (Data node or Algo node. following the specifications of workflow.yaml)
+        """
+        node_names = []
+
+        for _, node in config.nodeDict.items():
+            # NOTE: Switching the property to compare by node type
+            node_name = (
+                os.path.basename(node.data.path)
+                if node.type == NodeType.ALGO
+                else node.data.fileType
+            )
+            node_names.append(node_name)
+
+        return node_names

--- a/studio/app/optinist/core/expdb/batch_const.py
+++ b/studio/app/optinist/core/expdb/batch_const.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+LOCKFILE_NAME = "process.lock"
+FLAG_FILE_EXT = ".proc"
+
+
+class ProcessCommand(Enum):
+    REGIST = "regist"
+    REGIST_METADATA = "regist_metadata"
+    DELETE = "delete"

--- a/studio/app/optinist/core/expdb/batch_const.py
+++ b/studio/app/optinist/core/expdb/batch_const.py
@@ -8,3 +8,16 @@ class ProcessCommand(Enum):
     REGIST = "regist"
     REGIST_METADATA = "regist_metadata"
     DELETE = "delete"
+
+
+class SupportedRoiMethod(Enum):
+    CAIMAN = "caiman"
+    SUITE2P = "suite2p"
+
+    @classmethod
+    def get_roi_method_from_node(cls, node_name: str) -> "SupportedRoiMethod":
+        NODE_ROI_METHOD_MAP = {
+            "caiman_cnmf_preprocessing": cls.CAIMAN,
+            "suite2p_preprocessing": cls.SUITE2P,
+        }
+        return NODE_ROI_METHOD_MAP.get(node_name)

--- a/studio/app/optinist/core/expdb/batch_runner.py
+++ b/studio/app/optinist/core/expdb/batch_runner.py
@@ -7,7 +7,6 @@ import os
 import pathlib
 import traceback
 from contextlib import contextmanager
-from enum import Enum
 
 import yaml
 from lauda import stopwatch, stopwatchcm
@@ -17,6 +16,11 @@ from studio.app.common.core.users.crud_organizations import get_organization
 from studio.app.common.db.database import session_scope
 from studio.app.dir_path import DIRPATH
 from studio.app.expdb_dir_path import EXPDB_DIRPATH
+from studio.app.optinist.core.expdb.batch_const import (
+    FLAG_FILE_EXT,
+    LOCKFILE_NAME,
+    ProcessCommand,
+)
 from studio.app.optinist.core.expdb.batch_unit import ExpDbBatch
 from studio.app.optinist.core.expdb.crud_cells import bulk_insert_cells
 from studio.app.optinist.core.expdb.crud_configs import summarize_experiment_metadata
@@ -29,15 +33,6 @@ from studio.app.optinist.schemas.expdb.experiment import (
     ExpDbExperimentCreate,
     ExpDbExperimentUpdate,
 )
-
-LOCKFILE_NAME = "process.lock"
-FLAG_FILE_EXT = ".proc"
-
-
-class ProcessCommand(Enum):
-    REGIST = "regist"
-    REGIST_METADATA = "regist_metadata"
-    DELETE = "delete"
 
 
 class ProcessResult:

--- a/studio/app/optinist/core/expdb/expdb_data.py
+++ b/studio/app/optinist/core/expdb/expdb_data.py
@@ -102,3 +102,26 @@ class ExpDbPathIdsUtil:
             os.path.basename(output_path).split(ExpDbPathIds.ID_DELIMITER)[:2]
         )
         return ExpDbPathIds(exp_id=exp_id)
+
+
+@dataclass
+class BatchProcFile:
+    command: str
+    roi_method: Optional[str] = None
+
+
+@dataclass
+class BatchProcFileExt(BatchProcFile):
+    exp_id: Optional[str] = None
+    file_path: Optional[str] = None
+
+    def __post_init__(self):
+        if self.exp_id:
+            exp_ids = ExpDbPathIds(exp_id=self.exp_id)
+            self.file_path = join_filepath(
+                [
+                    EXPDB_DIRPATH.EXPDB_DIR,
+                    exp_ids.subject_id,
+                    f"{self.exp_id}.proc",
+                ]
+            )

--- a/studio/app/optinist/core/expdb/expdb_validator.py
+++ b/studio/app/optinist/core/expdb/expdb_validator.py
@@ -1,5 +1,6 @@
 from studio.app.common.core.workflow.workflow_reader import WorkflowConfigReader
 from studio.app.common.schemas.workflow import WorkflowConfig
+from studio.app.optinist.core.expdb.batch_const import SupportedRoiMethod
 
 
 class ExpDbValidator:
@@ -42,3 +43,20 @@ class ExpDbValidator:
         acceptable_nodes_matched = sorted(check_nodes) == sorted(list(acceptable_nodes))
 
         return acceptable_nodes_matched
+
+    @staticmethod
+    def validate_batch_roi_method(config: WorkflowConfig) -> SupportedRoiMethod:
+        check_nodes = WorkflowConfigReader.extract_node_names_in_workflow(config)
+
+        # Note: Only one of the optional nodes is accepted.
+        roi_node_name = None
+        for accept_optional_node in __class__._BATCH_ACCEPTABLE_OPTIONAL_NODES:
+            if accept_optional_node in check_nodes:
+                roi_node_name = accept_optional_node
+                break  # Break when one item is added.
+
+        return (
+            SupportedRoiMethod.get_roi_method_from_node(roi_node_name)
+            if roi_node_name
+            else None
+        )

--- a/studio/app/optinist/core/expdb/expdb_validator.py
+++ b/studio/app/optinist/core/expdb/expdb_validator.py
@@ -1,0 +1,44 @@
+from studio.app.common.core.workflow.workflow_reader import WorkflowConfigReader
+from studio.app.common.schemas.workflow import WorkflowConfig
+
+
+class ExpDbValidator:
+    # List of Layout-Capable Nodes
+    _BATCH_ACCEPTABLE_REQUIRED_NODES = frozenset(
+        {
+            "microscope_expdb",
+            "preprocessing",
+            "analyze_stats",
+        }
+    )
+    _BATCH_ACCEPTABLE_OPTIONAL_NODES = frozenset(
+        {
+            "caiman_cnmf_preprocessing",
+            "suite2p_preprocessing",
+        }
+    )
+    BATCH_ACCEPTABLE_NODES = list(
+        _BATCH_ACCEPTABLE_REQUIRED_NODES | _BATCH_ACCEPTABLE_OPTIONAL_NODES
+    )
+
+    @staticmethod
+    def validate_batch_nodes_in_workflow(config: WorkflowConfig) -> bool:
+        acceptable_nodes = set(__class__._BATCH_ACCEPTABLE_REQUIRED_NODES)
+        check_nodes = WorkflowConfigReader.extract_node_names_in_workflow(config)
+
+        # Note: Only one of the optional nodes is accepted.
+        is_optional_node_exists = False
+        for accept_optional_node in __class__._BATCH_ACCEPTABLE_OPTIONAL_NODES:
+            if accept_optional_node in check_nodes:
+                is_optional_node_exists = True
+                acceptable_nodes.add(accept_optional_node)
+                break  # Break when one item is added.
+
+        # Set default optional node
+        if not is_optional_node_exists:
+            return False
+
+        # Exact match check for node list
+        acceptable_nodes_matched = sorted(check_nodes) == sorted(list(acceptable_nodes))
+
+        return acceptable_nodes_matched

--- a/studio/app/optinist/core/expdb/workflow_expdb_batch_runner.py
+++ b/studio/app/optinist/core/expdb/workflow_expdb_batch_runner.py
@@ -1,15 +1,29 @@
+import shutil
+from dataclasses import asdict
+
+import yaml
 from fastapi import BackgroundTasks, HTTPException, status
+from zc import lockfile
 
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.workflow.workflow import RunItem
+from studio.app.common.core.workflow.workflow_reader import WorkflowConfigReader
 from studio.app.common.core.workflow.workflow_runner import WorkflowRunner
 from studio.app.common.core.workflow.workflow_writer import WorkflowConfigWriter
+from studio.app.optinist.core.expdb.batch_const import LOCKFILE_NAME, ProcessCommand
+from studio.app.optinist.core.expdb.expdb_data import (
+    BatchProcFile,
+    BatchProcFileExt,
+    ExpDbPathIdsUtil,
+)
 from studio.app.optinist.core.expdb.expdb_validator import ExpDbValidator
 
 logger = AppLogger.get_logger()
 
 
 class WorkflowExpdbBatchRunner:
+    BATCH_INPUT_NODE_NAME = "microscope_expdb"
+
     def __init__(self, workspace_id: str, unique_id: str, runItem: RunItem) -> None:
         self.workspace_id = workspace_id
         self.unique_id = unique_id
@@ -50,4 +64,70 @@ class WorkflowExpdbBatchRunner:
             self.workspace_id, self.unique_id, self.runItem
         ).finish_workflow_without_run()
 
-        # TODO: Subsequent processing needs to be implemented (Kick analysis batch)
+        # ------------------------------------------------------------
+        # Write workflow yaml
+        # ------------------------------------------------------------
+
+        batch_input_node = WorkflowConfigReader.find_node_in_workflow(
+            workflow_config, __class__.BATCH_INPUT_NODE_NAME
+        )
+        assert batch_input_node, f"Input not found: [{__class__.BATCH_INPUT_NODE_NAME}]"
+
+        src_workflow_yaml_path = WorkflowConfigReader.get_config_yaml_path(
+            self.workspace_id, self.unique_id
+        )
+
+        # Get the path to copy workflow yaml
+        # Note: The path of the batch input node corresponds to the exp_id.
+        exp_id = batch_input_node.data.path
+        dest_workflow_yaml_path = ExpDbPathIdsUtil.create_expdb_file_path(
+            exp_id,
+            f"{exp_id}_workflow.yaml",
+        )
+
+        logger.info(f"Generate workflow yaml for batch [{dest_workflow_yaml_path}]")
+
+        # Deploy the workflow yaml to the target directory
+        shutil.copy(src_workflow_yaml_path, dest_workflow_yaml_path)
+
+        # ------------------------------------------------------------
+        # Write .proc file
+        # ------------------------------------------------------------
+
+        roi_method = ExpDbValidator.validate_batch_roi_method(workflow_config)
+        assert roi_method, f"Invalid roi_method [{roi_method}]"
+
+        # Generate .proc file contents
+        proc_file = BatchProcFileExt(
+            exp_id=exp_id,
+            command=ProcessCommand.REGIST.value,
+            roi_method=roi_method.value,
+        )
+
+        logger.info(f"Generate .proc for batch [{proc_file}]")
+
+        # Write .proc file
+        # Check the status to see if batch processing is running (check the lock file).
+        # @see studio/app/optinist/core/expdb/batch_runner.py
+        proc_lock_file = None
+        try:
+            proc_lock_file = lockfile.LockFile(LOCKFILE_NAME)
+
+            # Write .proc file
+            with open(proc_file.file_path, "w") as f:
+                store_proc_file = BatchProcFile(
+                    command=proc_file.command, roi_method=proc_file.roi_method
+                )
+                yaml.dump(asdict(store_proc_file), f)
+
+        except lockfile.LockError as e:
+            err_message = (
+                f"Proc file lock error. already running. [expid: {exp_id}] - {e}"
+            )
+            logger.error(err_message)
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=err_message
+            )
+        finally:
+            if proc_lock_file:
+                proc_lock_file.close()

--- a/studio/app/optinist/core/expdb/workflow_expdb_batch_runner.py
+++ b/studio/app/optinist/core/expdb/workflow_expdb_batch_runner.py
@@ -1,8 +1,10 @@
-from fastapi import BackgroundTasks
+from fastapi import BackgroundTasks, HTTPException, status
 
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.workflow.workflow import RunItem
 from studio.app.common.core.workflow.workflow_runner import WorkflowRunner
+from studio.app.common.core.workflow.workflow_writer import WorkflowConfigWriter
+from studio.app.optinist.core.expdb.expdb_validator import ExpDbValidator
 
 logger = AppLogger.get_logger()
 
@@ -15,8 +17,35 @@ class WorkflowExpdbBatchRunner:
 
     def run_batch_workflow(self, background_tasks: BackgroundTasks):
         # ------------------------------------------------------------
+        # Validate workflow config
+        # ------------------------------------------------------------
+
+        workflow_config = WorkflowConfigWriter(
+            workspace_id=self.workspace_id,
+            unique_id=self.unique_id,
+            nodeDict=self.runItem.nodeDict,
+            edgeDict=self.runItem.edgeDict,
+        ).create_config()
+
+        is_valid_nodes = ExpDbValidator.validate_batch_nodes_in_workflow(
+            workflow_config
+        )
+
+        if not is_valid_nodes:
+            err_message = (
+                "Invalid batch workflow nodes: "
+                f"acceptable nodes={ExpDbValidator.BATCH_ACCEPTABLE_NODES}"
+            )
+            logger.error(err_message)
+
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=err_message
+            )
+
+        # ------------------------------------------------------------
         # Save Batch Run Template Workflow
         # ------------------------------------------------------------
+
         WorkflowRunner(
             self.workspace_id, self.unique_id, self.runItem
         ).finish_workflow_without_run()

--- a/studio/app/optinist/routers/expdb.py
+++ b/studio/app/optinist/routers/expdb.py
@@ -971,6 +971,10 @@ async def expdb_batch_run(
             detail=str(e).strip('"'),  # Remove quotes from the KeyError message
         )
 
+    except HTTPException as e:
+        logger.error(e, exc_info=True)
+        raise e
+
     except Exception as e:
         logger.error(e, exc_info=True)
         raise HTTPException(

--- a/studio/app/optinist/wrappers/expdb/__init__.py
+++ b/studio/app/optinist/wrappers/expdb/__init__.py
@@ -7,6 +7,9 @@ from studio.app.optinist.wrappers.expdb.curvefit_tuning import curvefit_tuning
 from studio.app.optinist.wrappers.expdb.preprocessing import preprocessing
 from studio.app.optinist.wrappers.expdb.stat_file_convert import stat_file_convert
 from studio.app.optinist.wrappers.expdb.vector_average import vector_average
+from studio.app.optinist.wrappers.suite2p.suite2p_preprocessing import (
+    suite2p_preprocessing,
+)
 
 expdb_wrapper_dict = {
     "expdb": {
@@ -18,6 +21,10 @@ expdb_wrapper_dict = {
             "caiman_cnmf_preprocessing": {
                 "function": caiman_cnmf_preprocessing,
                 "conda_name": "caiman",
+            },
+            "suite2p_preprocessing": {
+                "function": suite2p_preprocessing,
+                "conda_name": "suite2p",
             },
         },
         "analysis_preset": {

--- a/studio/app/optinist/wrappers/suite2p/params/suite2p_preprocessing.yaml
+++ b/studio/app/optinist/wrappers/suite2p/params/suite2p_preprocessing.yaml
@@ -1,0 +1,3 @@
+# Suite2p Preprocessing for ExpDB Workflow
+
+# TODO: dummy version

--- a/studio/app/optinist/wrappers/suite2p/suite2p_preprocessing.py
+++ b/studio/app/optinist/wrappers/suite2p/suite2p_preprocessing.py
@@ -16,7 +16,6 @@ from studio.app.optinist.dataclass import (  # EditRoiData,
 def suite2p_preprocessing(
     images: ImageData, output_dir: str, params: dict = None, **kwargs
 ) -> dict(fluorescence=FluoData, iscell=IscellData, processed_data=ExpDbData):
-
     # TODO: Mock version
     info = {}
 

--- a/studio/app/optinist/wrappers/suite2p/suite2p_preprocessing.py
+++ b/studio/app/optinist/wrappers/suite2p/suite2p_preprocessing.py
@@ -1,0 +1,23 @@
+"""
+Suite2p preprocessing for ExpDB workflow.
+
+Performs Suite2p ROI detection and generates ExpDB-compatible output files
+for integration with the analyze_stats pipeline.
+"""
+
+from studio.app.common.dataclass import ImageData
+from studio.app.optinist.dataclass import (  # EditRoiData,
+    ExpDbData,
+    FluoData,
+    IscellData,
+)
+
+
+def suite2p_preprocessing(
+    images: ImageData, output_dir: str, params: dict = None, **kwargs
+) -> dict(fluorescence=FluoData, iscell=IscellData, processed_data=ExpDbData):
+
+    # TODO: Mock version
+    info = {}
+
+    return info

--- a/studio/tests/app/common/core/workflow/test_workflow_reader.py
+++ b/studio/tests/app/common/core/workflow/test_workflow_reader.py
@@ -86,3 +86,12 @@ def test_read_edgeDict():
 
     assert isinstance(edgeDict, dict)
     assert isinstance(edgeDict["sample1"], Edge)
+
+def test_find_node():
+    workflow_config = WorkflowConfigReader.read(workspace_id, unique_id)
+
+    node = WorkflowConfigReader.find_node_in_workflow(
+        workflow_config, "suite2p_file_convert"
+    )
+
+    assert node

--- a/studio/tests/app/common/core/workflow/test_workflow_reader.py
+++ b/studio/tests/app/common/core/workflow/test_workflow_reader.py
@@ -87,6 +87,7 @@ def test_read_edgeDict():
     assert isinstance(edgeDict, dict)
     assert isinstance(edgeDict["sample1"], Edge)
 
+
 def test_find_node():
     workflow_config = WorkflowConfigReader.read(workspace_id, unique_id)
 

--- a/studio/tests/app/optinist/core/expdb/test_expdb_validator.py
+++ b/studio/tests/app/optinist/core/expdb/test_expdb_validator.py
@@ -1,0 +1,149 @@
+from studio.app.common.core.workflow.workflow import Node, NodeData
+from studio.app.common.core.workflow.workflow_writer import WorkflowConfigWriter
+from studio.app.common.schemas.workflow import WorkflowConfig
+from studio.app.optinist.core.expdb.expdb_validator import ExpDbValidator
+
+workspace_id = "default"
+unique_id = "expdb_test"
+
+nodeDict_ = {
+    "input_0": Node(
+        id="input_0",
+        type="MicroscopeExpdbFileNode",
+        data=NodeData(
+            label="M000000_ori001",
+            param={},
+            path="M000000_ori001",
+            type="input",
+            fileType="microscope_expdb",
+        ),
+        position={},
+        style={},
+    ),
+    "preprocessing_0001": Node(
+        id="preprocessing_0001",
+        type="AlgorithmNode",
+        data=NodeData(
+            label="preprocessing",
+            param={},
+            path="expdb/preprocess_components/preprocessing",
+            type="algorithm",
+        ),
+        position={},
+        style={},
+    ),
+    "suite2p_preprocessing_0001": Node(
+        id="suite2p_preprocessing_0001",
+        type="AlgorithmNode",
+        data=NodeData(
+            label="suite2p_preprocessing",
+            param={},
+            path="expdb/preprocess_components/suite2p_preprocessing",
+            type="algorithm",
+        ),
+        position={},
+        style={},
+    ),
+    "caiman_cnmf_preprocessing_0001": Node(
+        id="caiman_cnmf_preprocessing_0001",
+        type="AlgorithmNode",
+        data=NodeData(
+            label="caiman_cnmf_preprocessing",
+            param={},
+            path="expdb/preprocess_components/caiman_cnmf_preprocessing",
+            type="algorithm",
+        ),
+        position={},
+        style={},
+    ),
+    "analyze_stats_0001": Node(
+        id="analyze_stats_0001",
+        type="AlgorithmNode",
+        data=NodeData(
+            label="analyze_stats",
+            param={},
+            path="expdb/analysis_preset/analyze_stats",
+            type="algorithm",
+        ),
+        position={},
+        style={},
+    ),
+}
+
+edgeDict_ = {}
+
+
+def test_validate_batch_nodes():
+    print("Valid expdb batch nodes:", ExpDbValidator.BATCH_ACCEPTABLE_NODES)
+
+    # ======================================================================
+    # Valid Cases
+    # ======================================================================
+
+    # ----------------------------------------
+    # Case. Valid 1
+    # ----------------------------------------
+
+    nodeDict = nodeDict_.copy()
+    del nodeDict["suite2p_preprocessing_0001"]
+
+    is_valid_nodes = __test_validate_batch_nodes(nodeDict)
+    assert is_valid_nodes
+
+    # ----------------------------------------
+    # Case. Valid 2
+    # ----------------------------------------
+
+    nodeDict = nodeDict_.copy()
+    del nodeDict["caiman_cnmf_preprocessing_0001"]
+
+    is_valid_nodes = __test_validate_batch_nodes(nodeDict)
+    assert is_valid_nodes
+
+    # ======================================================================
+    # Invalid Cases
+    # ======================================================================
+
+    # ----------------------------------------
+    # Case. Invalid 1
+    # ----------------------------------------
+
+    nodeDict = nodeDict_.copy()
+
+    is_valid_nodes = __test_validate_batch_nodes(nodeDict)
+    assert not is_valid_nodes
+
+    # ----------------------------------------
+    # Case. Invalid 2
+    # ----------------------------------------
+
+    nodeDict = nodeDict_.copy()
+    del nodeDict["suite2p_preprocessing_0001"]
+    del nodeDict["caiman_cnmf_preprocessing_0001"]
+
+    is_valid_nodes = __test_validate_batch_nodes(nodeDict)
+    assert not is_valid_nodes
+
+    # ----------------------------------------
+    # Case. Invalid 3
+    # ----------------------------------------
+
+    nodeDict = nodeDict_.copy()
+    del nodeDict["analyze_stats_0001"]
+
+    is_valid_nodes = __test_validate_batch_nodes(nodeDict)
+    assert not is_valid_nodes
+
+
+def __test_validate_batch_nodes(nodeDict: dict):
+    workflow_config = WorkflowConfigWriter(
+        workspace_id=workspace_id,
+        unique_id=unique_id,
+        nodeDict=nodeDict,
+        edgeDict=edgeDict_,
+    ).create_config()
+    assert isinstance(workflow_config, WorkflowConfig)
+
+    is_valid_nodes = ExpDbValidator.validate_batch_nodes_in_workflow(workflow_config)
+
+    return is_valid_nodes


### PR DESCRIPTION
### Content

Since the first issue (#462), the following implementations have been added:

#### Implementation in the current version

- Workflow Screen
  - Batch Run Button Operation
    - Validation
    - Only valid node configurations are allowed (patterns bellow)
        1. `microscope_expdb -> preprocessing -> caiman_cnmf_preprocessing -> analyze_stats`
        2. `microscope_expdb -> preprocessing -> suite2p_preprocessing -> analyze_stats`
  - Batch Start
    - An error occurs if a batch process is already running
    - Batch processing starts after validation is successful
    - Necessary files (workflow.yaml, .proc) are registered in the target data folder

#### Planned Future Implementations

- Feature Access Permission Control
- Workflow Screen Improvements
  - Data Acquisition Enhancements: Ability to Acquire Pre-Analysis Data
  - Multiple Data Selection
  - Adjustments to Node Display in the Left Side Menu
- etc.

### Testcase

- Note: Please run `alembic upgrade head` before checking.

- [x] Verify that each UI function of "Implementation in the current version" works 