### PR TITLE
Analysis batch GUI execution (Switching the display of nodes)

### DIFF
--- a/frontend/src/api/algolist/AlgoList.ts
+++ b/frontend/src/api/algolist/AlgoList.ts
@@ -1,4 +1,5 @@
 import { BASE_URL } from "const/API"
+import { WORKSPACE_TYPE } from "const/Workspace"
 import axios from "utils/axios"
 
 export type AlgoListDTO = {
@@ -19,7 +20,13 @@ export type AlgorithmInfo = {
   isNone?: boolean
 }
 
-export async function getAlgoListApi(): Promise<AlgoListDTO> {
-  const response = await axios.get(`${BASE_URL}/algolist`)
+export async function getAlgoListApi(
+  workspace_type?: number,
+): Promise<AlgoListDTO> {
+  const endpoint =
+    workspace_type === WORKSPACE_TYPE.EXPDB_BATCH
+      ? `${BASE_URL}/algolist/expdb`
+      : `${BASE_URL}/algolist`
+  const response = await axios.get(endpoint)
   return response.data
 }

--- a/frontend/src/store/slice/AlgorithmList/AlgorithmListActions.ts
+++ b/frontend/src/store/slice/AlgorithmList/AlgorithmListActions.ts
@@ -2,13 +2,17 @@ import { createAsyncThunk } from "@reduxjs/toolkit"
 
 import { AlgoListDTO, getAlgoListApi } from "api/algolist/AlgoList"
 import { ALGORITHM_LIST_SLICE_NAME } from "store/slice/AlgorithmList/AlgorithmListType"
+import { selectCurrentWorkspaceType } from "store/slice/Workspace/WorkspaceSelector"
+import { RootState } from "store/store"
 
 export const getAlgoList = createAsyncThunk<AlgoListDTO, void>(
   `${ALGORITHM_LIST_SLICE_NAME}/getAlgoList`,
   async (_, thunkAPI) => {
-    const { rejectWithValue } = thunkAPI
+    const { rejectWithValue, getState } = thunkAPI
     try {
-      const response = await getAlgoListApi()
+      const state = getState() as RootState
+      const workspace_type = selectCurrentWorkspaceType(state)
+      const response = await getAlgoListApi(workspace_type)
       return response
     } catch (e) {
       return rejectWithValue(e)

--- a/frontend/src/store/slice/AlgorithmList/AlgorithmListSlice.ts
+++ b/frontend/src/store/slice/AlgorithmList/AlgorithmListSlice.ts
@@ -6,6 +6,7 @@ import {
   AlgorithmListType,
 } from "store/slice/AlgorithmList/AlgorithmListType"
 import { convertToAlgoListType } from "store/slice/AlgorithmList/AlgorithmListUtils"
+import { getWorkspace } from "store/slice/Workspace/WorkspaceActions"
 
 export const initialState: AlgorithmListType = {
   isLatest: false,
@@ -15,13 +16,23 @@ export const initialState: AlgorithmListType = {
 export const algorithmListSlice = createSlice({
   name: ALGORITHM_LIST_SLICE_NAME,
   initialState,
-  reducers: {},
+  reducers: {
+    resetAlgoListCache: (state) => {
+      state.isLatest = false
+    },
+  },
   extraReducers: (builder) => {
-    builder.addCase(getAlgoList.fulfilled, (state, action) => {
-      state.tree = convertToAlgoListType(action.payload)
-      state.isLatest = true
-    })
+    builder
+      .addCase(getAlgoList.fulfilled, (state, action) => {
+        state.tree = convertToAlgoListType(action.payload)
+        state.isLatest = true
+      })
+      .addCase(getWorkspace.fulfilled, (state) => {
+        // Reset AlgoList cache when workspace is switched
+        state.isLatest = false
+      })
   },
 })
 
+export const { resetAlgoListCache } = algorithmListSlice.actions
 export default algorithmListSlice.reducer

--- a/studio/app/common/routers/algolist.py
+++ b/studio/app/common/routers/algolist.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter
 from studio.app.common.core.snakemake.smk_utils import SmkInternalUtils
 from studio.app.common.schemas.algolist import Algo, AlgoList, Arg, Return
 from studio.app.const import NOT_DISPLAY_ARGS_LIST
-from studio.app.wrappers import wrapper_dict
+from studio.app.wrappers import wrapper_dict, wrapper_expdb_dict
 
 router = APIRouter()
 
@@ -100,3 +100,11 @@ async def get_algolist() -> Dict[str, Algo]:
     """
 
     return NestDictGetter.get_nest_dict(wrapper_dict, "")
+
+
+@router.get("/algolist/expdb", response_model=AlgoList, tags=["others"])
+async def get_expdb_algolist() -> Dict[str, Algo]:
+    """
+    Similar to `/algolist`, but returns only expdb related algolists
+    """
+    return NestDictGetter.get_nest_dict(wrapper_expdb_dict, "")

--- a/studio/app/wrappers.py
+++ b/studio/app/wrappers.py
@@ -1,6 +1,10 @@
 # from studio.app.common.wrappers import wrapper_dict as common_wrapper_dict
+from studio.app.optinist.wrappers import expdb_wrapper_dict
 from studio.app.optinist.wrappers import wrapper_dict as optinist_wrapper_dict
 
 wrapper_dict = {}
 # wrapper_dict.update(**common_wrapper_dict)
 wrapper_dict.update(**optinist_wrapper_dict)
+
+wrapper_expdb_dict = {}
+wrapper_expdb_dict.update(**expdb_wrapper_dict)


### PR DESCRIPTION
### Content

#### Implementation in this PR

- Workflow Screen
  - Switching the display of nodes in the left menu
    - <img width="328" height="463" alt="image" src="https://github.com/user-attachments/assets/f3ee9fcf-a64e-4e51-bd3f-5a80118b92e5" />
    1. Input nodes now only display `batch_database`
        -  \*this has already been addressed in a separate PR (#466), but is listed here for reference.
    2. Algorithm nodes now only display nodes belonging to `expdb` (this PR addresses this issue).

### Testcase

- [x] 1. If workspace type is "Analysis Batch (type:20)"
  - Only `batch_database` is displayed in the Input Nodes.
  - Only expdb-related nodes (`preprocess_components/*`, `analysis_preset/*`, `preset_components/*`) are displayed in Algorithm Nodes.
- [x] 2. If workspace type is not "Analysis Batch"
  - All standard nodes are displayed in the Input Nodes.
  - All standard nodes are displayed in the Algorithm Nodes.

### Note

\*The updates in this PR are relatively minor, but because this update is a unique feature requirement, it is being issued as its own PR for clarification.