### PR TITLE
Analysis batch GUI execution (Permission control)

### DIFF
--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -166,7 +166,7 @@ const columns = (
     filterable: false,
     sortable: false,
     flex: 1,
-    minWidth: 80,
+    minWidth: 120,
     renderCell: (params: GridRenderCellParams<GridValidRowModel>) => (
       <span>
         {WORKSPACE_TYPE_LABEL[params.value as WORKSPACE_TYPE] ||

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -46,7 +46,10 @@ import {
   WORKSPACE_TYPE_LABEL,
   WORKSPACE_TYPE_OPTIONS,
 } from "const/Workspace"
-import { selectCurrentUser } from "store/slice/User/UserSelector"
+import {
+  selectCurrentUser,
+  isExpDbBatchRunnableAdmin,
+} from "store/slice/User/UserSelector"
 import { resetVisualizeLayout } from "store/slice/VisualizeItem/VisualizeItemSlice"
 import {
   delWorkspace,
@@ -242,15 +245,18 @@ const columns = (
     minWidth: 70,
     filterable: false, // todo enable when api complete
     sortable: false, // todo enable when api complete
-    renderCell: (params: GridRenderCellParams<GridValidRowModel>) =>
-      isMine(user, params.row?.user?.id) ? (
+    renderCell: (params: GridRenderCellParams<GridValidRowModel>) => {
+      const shouldHideShareButton =
+        params.row?.type === WORKSPACE_TYPE.EXPDB_BATCH
+      return isMine(user, params.row?.user?.id) && !shouldHideShareButton ? (
         <IconButton
           onClick={() => handleOpenPopupShare(params.row.id)}
           color={params.row.shared_count ? "primary" : "default"}
         >
           <GroupsIcon />
         </IconButton>
-      ) : null,
+      ) : null
+    },
   },
   {
     field: "delete",
@@ -298,6 +304,7 @@ const PopupNew = ({
   handleOkNew,
   error,
 }: PopupType) => {
+  const isExpDbAdmin = useSelector(isExpDbBatchRunnableAdmin)
   if (!setNewWorkSpace) return null
   const handleName = (event: ChangeEvent<HTMLInputElement>) => {
     setNewWorkSpace({
@@ -329,23 +336,25 @@ const PopupNew = ({
             helperText={error && !value?.name ? error : ""}
             variant="standard"
           />
-          <FormControl component="fieldset" sx={{ width: "100%" }}>
-            <FormLabel component="legend">Type</FormLabel>
-            <RadioGroup
-              row
-              value={value?.type ?? WORKSPACE_TYPE.NORMAL}
-              onChange={handleType}
-            >
-              {WORKSPACE_TYPE_OPTIONS.map((option) => (
-                <FormControlLabel
-                  key={option.value}
-                  value={option.value}
-                  control={<Radio />}
-                  label={option.label}
-                />
-              ))}
-            </RadioGroup>
-          </FormControl>
+          {isExpDbAdmin && (
+            <FormControl component="fieldset" sx={{ width: "100%" }}>
+              <FormLabel component="legend">Type</FormLabel>
+              <RadioGroup
+                row
+                value={value?.type ?? WORKSPACE_TYPE.NORMAL}
+                onChange={handleType}
+              >
+                {WORKSPACE_TYPE_OPTIONS.map((option) => (
+                  <FormControlLabel
+                    key={option.value}
+                    value={option.value}
+                    control={<Radio />}
+                    label={option.label}
+                  />
+                ))}
+              </RadioGroup>
+            </FormControl>
+          )}
         </DialogContent>
         <DialogActions>
           <Button variant={"outlined"} onClick={handleClose}>

--- a/frontend/src/store/slice/User/UserSelector.ts
+++ b/frontend/src/store/slice/User/UserSelector.ts
@@ -23,3 +23,9 @@ export const isAdminOrManager = (state: RootState) => {
     state.user.currentUser?.role_id as number,
   )
 }
+
+export const isExpDbBatchRunnableAdmin = (state: RootState) => {
+  return [ROLE.ADMIN, ROLE.DATA_MANAGER].includes(
+    state.user.currentUser?.role_id as number,
+  )
+}

--- a/studio/app/common/core/workspace/workspace.py
+++ b/studio/app/common/core/workspace/workspace.py
@@ -1,0 +1,8 @@
+from enum import IntEnum
+
+
+class WorkspaceType(IntEnum):
+    DEFAULT = 0
+    NORMAL = 1
+    BATCH = 2
+    EXPDB_BATCH = 10

--- a/studio/app/common/core/workspace/workspace_dependencies.py
+++ b/studio/app/common/core/workspace/workspace_dependencies.py
@@ -5,8 +5,12 @@ from sqlmodel import Session, or_
 
 from studio.app.common import models as common_model
 from studio.app.common.core.auth.auth_dependencies import get_current_user
+from studio.app.common.core.logger import AppLogger
+from studio.app.common.core.workspace.workspace import WorkspaceType
 from studio.app.common.db.database import get_db
 from studio.app.common.schemas.users import User
+
+logger = AppLogger.get_logger()
 
 
 async def is_workspace_owner(
@@ -25,9 +29,13 @@ async def is_workspace_owner(
     )
 
     if workspace is None:
+        logger.error("Workspace is not found")
         raise HTTPException(status_code=403, detail="Operation is not available")
-    else:
-        return True
+
+    if not check_expdb_batch_type_workspace_permission(current_user, workspace):
+        raise HTTPException(status_code=403, detail="Workspace is not available")
+
+    return True
 
 
 async def is_workspace_available(
@@ -55,6 +63,30 @@ async def is_workspace_available(
     )
 
     if workspace is None:
+        logger.error("Workspace is not found")
         raise HTTPException(status_code=403, detail="Workspace is not available")
-    else:
-        return True
+
+    if not check_expdb_batch_type_workspace_permission(current_user, workspace):
+        raise HTTPException(status_code=403, detail="Workspace is not available")
+
+    return True
+
+
+def check_expdb_batch_type_workspace_permission(
+    current_user: User, workspace: common_model.Workspace
+) -> bool:
+    """
+    Check EXPDB_BATCH type workspace's permission
+    """
+    if (
+        workspace.type == WorkspaceType.EXPDB_BATCH
+        and not current_user.is_expdb_batch_runnable_admin
+    ):
+        logger.error(
+            "Invalid access to an EXPDB_BATCH type workspace"
+            f" [type: {workspace.type}]"
+            f" [has_permission: {current_user.is_expdb_batch_runnable_admin}]"
+        )
+        return False
+
+    return True

--- a/studio/app/common/routers/workspace.py
+++ b/studio/app/common/routers/workspace.py
@@ -13,6 +13,7 @@ from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.common.core.workflow.workflow import WorkflowRunStatus
 from studio.app.common.core.workspace.workspace_dependencies import (
+    check_expdb_batch_type_workspace_permission,
     is_workspace_available,
     is_workspace_owner,
 )
@@ -197,6 +198,11 @@ def create_workspace(
     workspace = common_model.Workspace(
         **workspace.dict(), user_id=current_user.id, deleted=0
     )
+
+    # Check EXPDB_BATCH type workspace's permission
+    if not check_expdb_batch_type_workspace_permission(current_user, workspace):
+        raise HTTPException(status_code=403, detail="Workspace is not available")
+
     db.add(workspace)
     db.commit()
     db.refresh(workspace)

--- a/studio/app/common/schemas/users.py
+++ b/studio/app/common/schemas/users.py
@@ -48,6 +48,10 @@ class User(BaseModel):
     def is_admin_data(self) -> bool:
         return self.is_admin or self.role_id == UserRole.data_manager
 
+    @property
+    def is_expdb_batch_runnable_admin(self) -> bool:
+        return self.is_admin or self.role_id == UserRole.data_manager
+
     class Config:
         orm_mode = True
 

--- a/studio/app/optinist/routers/expdb.py
+++ b/studio/app/optinist/routers/expdb.py
@@ -949,9 +949,6 @@ def update_multiple_experiment_database_share_status(
 async def expdb_batch_run(
     workspace_id: str, runItem: RunItem, background_tasks: BackgroundTasks
 ):
-    # TODO: Demo version of expdb_batch_run API
-    # TODO: Permission control required
-
     try:
         new_unique_id = WorkflowRunner.create_workflow_unique_id()
         WorkflowExpdbBatchRunner(


### PR DESCRIPTION
### Content

#### Implementation in this PR

- Workspace Screen
  - Apply permission control to the UI for workspaces whose workspace type is WORKSPACE_TYPE.EXPDB_BATCH
    1. Control whether to create Workspace for Analysis Batch Type (Allow only if user has permission)
        - <img width="1060" height="511" alt="image" src="https://github.com/user-attachments/assets/3554d5d4-8172-4243-aa0c-9d7ae7e883b5" />
    2. Controlling whether Analysis Batch Type Workspaces can be shared (Analysis Batch Type Workspace cannot be shared)
        - <img width="1039" height="554" alt="image" src="https://github.com/user-attachments/assets/2e2c3433-1523-4dff-817e-17a7b8c828a5" />

- Workflow Screen
  - Apply permission control to the API for workspaces whose workspace type is WORKSPACE_TYPE.EXPDB_BATCH
    - \*In reality, permission control is performed in the UI, so unauthorized calls to the API are not possible via the normal route. However, for safety reasons, permission control is also applied to the API side.

### Testcase

- [x] 1. When the user's role is included in `Admin` or `DataManager`
  - [x] The Type selection item is displayed in the Workspaces New Dialog. And it is possible to create a Workspace of Type "Analysis Batch".
  - [x] Workspaces of Type "Analysis Batch" cannot be shared.
- [x] 2. If workspace type is not included in `Admin` or `DataManager`
  - [x] The Type selection item is not displayed in the Workspaces New Dialog
  - [x] Normal operations within Workspace can be performed without any problems.
    - Workflow Run
    - Record Delete

#### Note

- Backend API testing cannot be performed via the UI, so we'll skip it here.
  \*API permission control is centrally managed by the router dependencies below.
  - studio/app/common/core/workspace/workspace_dependencies.py 
