### PR TITLE
Prepared expdb batch proc file related modules

### DIFF
--- a/studio/app/optinist/core/expdb/batch_const.py
+++ b/studio/app/optinist/core/expdb/batch_const.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 LOCKFILE_NAME = "process.lock"
-FLAG_FILE_EXT = ".proc"
+PROC_FILE_EXT = ".proc"
 
 
 class ProcessCommand(Enum):

--- a/studio/app/optinist/core/expdb/batch_runner.py
+++ b/studio/app/optinist/core/expdb/batch_runner.py
@@ -3,7 +3,6 @@ import datetime
 import logging
 import logging.config
 import os
-import pathlib
 import traceback
 from contextlib import contextmanager
 
@@ -25,7 +24,9 @@ from studio.app.optinist.core.expdb.crud_expdb import (
     update_experiment,
 )
 from studio.app.optinist.core.expdb.expdb_data import ProcessResult
+from studio.app.optinist.core.expdb.proc_file_data import ProcFile, ProcFileUtils
 from studio.app.optinist.core.expdb.proc_file_reader import ProcFileReader
+from studio.app.optinist.core.expdb.proc_file_writer import ProcFileWriter
 from studio.app.optinist.schemas.expdb.experiment import (
     ExpDbExperimentCreate,
     ExpDbExperimentUpdate,
@@ -301,7 +302,7 @@ class ExpDbBatchConcurrentProcess:
         start_time: datetime.datetime,
         logger_name: str,
     ) -> dict:
-        exp_id = ProcFileReader.parse_exp_id_from_path(proc_file_path)
+        exp_id = ProcFileUtils.parse_exp_id_from_path(proc_file_path)
         logger = cls.__init_process_logger(exp_id)
         logger.info(
             f"Process {os.getpid()} starting to \
@@ -496,44 +497,30 @@ class ExpDbBatchConcurrentProcess:
 
         # ----------------------------------------
         # 後処理
-        # - フラグファイル処理（ログ出力、リネーム）
+        # - proc file 処理（ログ出力、リネーム）
         # ----------------------------------------
 
-        # フラグファイル書き込みデータ作成
-        if not error:
-            result_log = {
-                "command": command,
-                "start_time": start_time,
-                "complete_time": datetime.datetime.now(),
-                "result": "success",
-                "log": "completed successfully.",
-            }
-        else:
-            result_log = {
-                "command": command,
-                "start_time": start_time,
-                "complete_time": datetime.datetime.now(),
-                "result": "error",
-                "log": "{}: {}".format(type(error), str(error)),
-            }
+        is_success = not error
 
-        # フラグファイル内容アップデート
-        with open(proc_file_path, "w") as yf:
-            yaml.dump(result_log, yf)
-
-        # フラグファイル名作成
-        if not error:
-            renamed_proc_file = proc_file_path + ".done"
-        else:
-            renamed_proc_file = proc_file_path + ".error"
-
-        # 過去のフラグファイルが存在する場合はリネーム
-        if os.path.isfile(renamed_proc_file):
-            ps = pathlib.Path(renamed_proc_file).stat()
-            st_mtime = datetime.datetime.fromtimestamp(ps.st_mtime).strftime(
-                "%Y%m%d%H%M%S"
+        # Create write data for proc file
+        if is_success:
+            result_proc = ProcFile(
+                command=command,
+                start_time=start_time,
+                complete_time=datetime.datetime.now(),
+                result="success",
+                log="completed successfully.",
             )
-            os.rename(renamed_proc_file, renamed_proc_file + "." + st_mtime)
+        else:
+            result_proc = ProcFile(
+                command=command,
+                start_time=start_time,
+                complete_time=datetime.datetime.now(),
+                result="error",
+                log="{}: {}".format(type(error), str(error)),
+            )
 
-        # フラグファイルリネーム
-        os.rename(proc_file_path, renamed_proc_file)
+        # Write and rename/backup proc file
+        ProcFileWriter.write_and_backup_proc_file(
+            proc_file_path, result_proc, is_success
+        )

--- a/studio/app/optinist/core/expdb/batch_runner.py
+++ b/studio/app/optinist/core/expdb/batch_runner.py
@@ -1,6 +1,5 @@
 import concurrent.futures
 import datetime
-import glob
 import logging
 import logging.config
 import os
@@ -16,11 +15,7 @@ from studio.app.common.core.users.crud_organizations import get_organization
 from studio.app.common.db.database import session_scope
 from studio.app.dir_path import DIRPATH
 from studio.app.expdb_dir_path import EXPDB_DIRPATH
-from studio.app.optinist.core.expdb.batch_const import (
-    FLAG_FILE_EXT,
-    LOCKFILE_NAME,
-    ProcessCommand,
-)
+from studio.app.optinist.core.expdb.batch_const import LOCKFILE_NAME, ProcessCommand
 from studio.app.optinist.core.expdb.batch_unit import ExpDbBatch
 from studio.app.optinist.core.expdb.crud_cells import bulk_insert_cells
 from studio.app.optinist.core.expdb.crud_configs import summarize_experiment_metadata
@@ -30,6 +25,7 @@ from studio.app.optinist.core.expdb.crud_expdb import (
     update_experiment,
 )
 from studio.app.optinist.core.expdb.expdb_data import ProcessResult
+from studio.app.optinist.core.expdb.proc_file_reader import ProcFileReader
 from studio.app.optinist.schemas.expdb.experiment import (
     ExpDbExperimentCreate,
     ExpDbExperimentUpdate,
@@ -163,18 +159,20 @@ class ExpDbBatchRunner:
 
         processResult = ProcessResult()
 
-        target_flag_files = self.__search_target_datasets()
+        # 処理対象datasets検索
+        self.logger_.info("proc files search path: %s", EXPDB_DIRPATH.EXPDB_DIR)
+        target_proc_files = ProcFileReader.find_proc_files()
 
         # 処理対象datasetsが存在しない場合は、ここで処理終了（return）
-        if len(target_flag_files) == 0:
+        if len(target_proc_files) == 0:
             self.logger_.info("No datasets found.")
             return processResult
 
         # 最大並列処理Process数を規定
-        max_workers = min(len(target_flag_files), self.parallel_workers)
+        max_workers = min(len(target_proc_files), self.parallel_workers)
         self.logger_.info(
             "Start processing datasets. [total: %d][max_workers: %d]",
-            len(target_flag_files),
+            len(target_proc_files),
             max_workers,
         )
 
@@ -186,13 +184,13 @@ class ExpDbBatchRunner:
             futures = [
                 executor.submit(
                     ExpDbBatchConcurrentProcess.process_single_dataset_entrypoint,
-                    flag_file=flag_file,
+                    proc_file_path=proc_file_path,
                     org_id=self.org_id,
                     start_time=self.start_time,
                     logger_name=__class__.LOGGER_NAME,
                 )
-                # 処理対象datasets検索：フラグファイル走査
-                for flag_file in target_flag_files
+                # 処理対象datasets検索：proc file走査
+                for proc_file_path in target_proc_files
             ]
 
             process_results = []
@@ -212,20 +210,6 @@ class ExpDbBatchRunner:
             summarize_experiment_metadata(db)
 
         return processResult
-
-    @stopwatch(callback=__stopwatch_callback)
-    def __search_target_datasets(self) -> list:
-        """
-        処理対象datasets検索
-        """
-        self.logger_.info("path: %s", EXPDB_DIRPATH.EXPDB_DIR)
-
-        # フラグファイル検索
-        target_flag_files = sorted(
-            glob.glob(EXPDB_DIRPATH.EXPDB_DIR + "/*/*" + FLAG_FILE_EXT)
-        )
-
-        return target_flag_files
 
 
 def dataset_process_stopwatch_callback(watch, function=None):
@@ -292,14 +276,10 @@ class ExpDbBatchConcurrentProcess:
 
         return logging.getLogger(cls.LOGGER_NAME)
 
-    @staticmethod
-    def __get_exp_id_from_flag_file(flag_file: str) -> str:
-        return os.path.basename(flag_file).split(".", 1)[0]
-
     @classmethod
     def process_single_dataset_entrypoint(
         cls,
-        flag_file: str,
+        proc_file_path: str,
         org_id: int,
         start_time: datetime.datetime,
         logger_name: str,
@@ -308,22 +288,24 @@ class ExpDbBatchConcurrentProcess:
         ATTENTION: This method does not use decorator (stopwatch)
             because it is an entrypoint of ProcessPoolExecutor.
         """
-        return cls.process_single_dataset(flag_file, org_id, start_time, logger_name)
+        return cls.process_single_dataset(
+            proc_file_path, org_id, start_time, logger_name
+        )
 
     @classmethod
     @stopwatch(callback=dataset_process_stopwatch_callback)
     def process_single_dataset(
         cls,
-        flag_file: str,
+        proc_file_path: str,
         org_id: int,
         start_time: datetime.datetime,
         logger_name: str,
     ) -> dict:
-        exp_id = cls.__get_exp_id_from_flag_file(flag_file)
+        exp_id = ProcFileReader.parse_exp_id_from_path(proc_file_path)
         logger = cls.__init_process_logger(exp_id)
         logger.info(
             f"Process {os.getpid()} starting to \
-                process exp_id: {exp_id}, flag_file: {flag_file}"
+                process exp_id: {exp_id}, proc_file_path: {proc_file_path}"
         )
 
         error = None
@@ -331,12 +313,11 @@ class ExpDbBatchConcurrentProcess:
         result = {"success": False, "exp_id": exp_id}
 
         try:
-            # フラグファイル read
-            with open(flag_file) as cfile:
-                config = yaml.safe_load(cfile)
+            # Read proc file
+            proc_file = ProcFileReader.read_from_path(proc_file_path)
 
             # コマンド判定
-            command = config.get("command") if config is not None else None
+            command = proc_file.command
 
             if command == ProcessCommand.REGIST.value:
                 cls.process_dataset_registration(
@@ -363,7 +344,7 @@ class ExpDbBatchConcurrentProcess:
             result["error"] = e
 
         finally:
-            cls.process_dataset_postprocess(flag_file, command, start_time, error)
+            cls.process_dataset_postprocess(proc_file_path, command, start_time, error)
 
             if error:
                 logger.error("finish process dataset: [exp_id: %s]", exp_id)
@@ -504,7 +485,7 @@ class ExpDbBatchConcurrentProcess:
     @classmethod
     def process_dataset_postprocess(
         cls,
-        flag_file: str,
+        proc_file_path: str,
         command: str,
         start_time: datetime.datetime,
         error: Exception = None,
@@ -537,22 +518,22 @@ class ExpDbBatchConcurrentProcess:
             }
 
         # フラグファイル内容アップデート
-        with open(flag_file, "w") as yf:
+        with open(proc_file_path, "w") as yf:
             yaml.dump(result_log, yf)
 
         # フラグファイル名作成
         if not error:
-            renamed_flag_file = flag_file + ".done"
+            renamed_proc_file = proc_file_path + ".done"
         else:
-            renamed_flag_file = flag_file + ".error"
+            renamed_proc_file = proc_file_path + ".error"
 
         # 過去のフラグファイルが存在する場合はリネーム
-        if os.path.isfile(renamed_flag_file):
-            ps = pathlib.Path(renamed_flag_file).stat()
+        if os.path.isfile(renamed_proc_file):
+            ps = pathlib.Path(renamed_proc_file).stat()
             st_mtime = datetime.datetime.fromtimestamp(ps.st_mtime).strftime(
                 "%Y%m%d%H%M%S"
             )
-            os.rename(renamed_flag_file, renamed_flag_file + "." + st_mtime)
+            os.rename(renamed_proc_file, renamed_proc_file + "." + st_mtime)
 
         # フラグファイルリネーム
-        os.rename(flag_file, renamed_flag_file)
+        os.rename(proc_file_path, renamed_proc_file)

--- a/studio/app/optinist/core/expdb/expdb_data.py
+++ b/studio/app/optinist/core/expdb/expdb_data.py
@@ -104,29 +104,6 @@ class ExpDbPathIdsUtil:
         return ExpDbPathIds(exp_id=exp_id)
 
 
-@dataclass
-class BatchProcFile:
-    command: str
-    roi_method: Optional[str] = None
-
-
-@dataclass
-class BatchProcFileExt(BatchProcFile):
-    exp_id: Optional[str] = None
-    file_path: Optional[str] = None
-
-    def __post_init__(self):
-        if self.exp_id:
-            exp_ids = ExpDbPathIds(exp_id=self.exp_id)
-            self.file_path = join_filepath(
-                [
-                    EXPDB_DIRPATH.EXPDB_DIR,
-                    exp_ids.subject_id,
-                    f"{self.exp_id}.proc",
-                ]
-            )
-
-
 class ProcessResult:
     def __init__(self):
         self.success_ids_ = []

--- a/studio/app/optinist/core/expdb/proc_file_data.py
+++ b/studio/app/optinist/core/expdb/proc_file_data.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.expdb_dir_path import EXPDB_DIRPATH
-from studio.app.optinist.core.expdb.batch_const import FLAG_FILE_EXT
+from studio.app.optinist.core.expdb.batch_const import PROC_FILE_EXT
 from studio.app.optinist.core.expdb.expdb_data import ExpDbPathIds
 
 
@@ -25,6 +25,6 @@ class ProcFileExt(ProcFile):
                 [
                     EXPDB_DIRPATH.EXPDB_DIR,
                     exp_ids.subject_id,
-                    f"{self.exp_id}{FLAG_FILE_EXT}",
+                    f"{self.exp_id}{PROC_FILE_EXT}",
                 ]
             )

--- a/studio/app/optinist/core/expdb/proc_file_data.py
+++ b/studio/app/optinist/core/expdb/proc_file_data.py
@@ -1,3 +1,5 @@
+import datetime
+import os
 from dataclasses import dataclass
 from typing import Optional
 
@@ -11,20 +13,33 @@ from studio.app.optinist.core.expdb.expdb_data import ExpDbPathIds
 class ProcFile:
     command: str
     roi_method: Optional[str] = None
+    start_time: Optional[datetime.datetime] = None
+    complete_time: Optional[datetime.datetime] = None
+    result: Optional[str] = None
+    log: Optional[str] = None
 
 
-@dataclass
-class ProcFileExt(ProcFile):
-    exp_id: Optional[str] = None
-    file_path: Optional[str] = None
+class ProcFileUtils:
+    @classmethod
+    def parse_exp_id_from_path(cls, file_path: str) -> str:
+        return os.path.basename(file_path).split(".", 1)[0]
 
-    def __post_init__(self):
-        if self.exp_id:
-            exp_ids = ExpDbPathIds(exp_id=self.exp_id)
-            self.file_path = join_filepath(
-                [
-                    EXPDB_DIRPATH.EXPDB_DIR,
-                    exp_ids.subject_id,
-                    f"{self.exp_id}{PROC_FILE_EXT}",
-                ]
-            )
+    @classmethod
+    def create_proc_file(cls, config: dict) -> ProcFile:
+        return ProcFile(
+            command=config.get("command"),
+            roi_method=config.get("roi_method"),
+        )
+
+    @classmethod
+    def get_proc_file_path(cls, exp_id: str) -> str:
+        exp_ids = ExpDbPathIds(exp_id=exp_id)
+        path = join_filepath(
+            [EXPDB_DIRPATH.EXPDB_DIR, exp_ids.subject_id, f"{exp_id}{PROC_FILE_EXT}"]
+        )
+        return path
+
+    @classmethod
+    def get_proc_file_wild_path(cls) -> str:
+        path = f"{EXPDB_DIRPATH.EXPDB_DIR}/*/*{PROC_FILE_EXT}"
+        return path

--- a/studio/app/optinist/core/expdb/proc_file_data.py
+++ b/studio/app/optinist/core/expdb/proc_file_data.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from studio.app.common.core.utils.filepath_creater import join_filepath
+from studio.app.expdb_dir_path import EXPDB_DIRPATH
+from studio.app.optinist.core.expdb.batch_const import FLAG_FILE_EXT
+from studio.app.optinist.core.expdb.expdb_data import ExpDbPathIds
+
+
+@dataclass
+class ProcFile:
+    command: str
+    roi_method: Optional[str] = None
+
+
+@dataclass
+class ProcFileExt(ProcFile):
+    exp_id: Optional[str] = None
+    file_path: Optional[str] = None
+
+    def __post_init__(self):
+        if self.exp_id:
+            exp_ids = ExpDbPathIds(exp_id=self.exp_id)
+            self.file_path = join_filepath(
+                [
+                    EXPDB_DIRPATH.EXPDB_DIR,
+                    exp_ids.subject_id,
+                    f"{self.exp_id}{FLAG_FILE_EXT}",
+                ]
+            )

--- a/studio/app/optinist/core/expdb/proc_file_reader.py
+++ b/studio/app/optinist/core/expdb/proc_file_reader.py
@@ -1,12 +1,7 @@
 import glob
-import os
 
 from studio.app.common.core.utils.config_handler import ConfigReader
-from studio.app.common.core.utils.filepath_creater import join_filepath
-from studio.app.expdb_dir_path import EXPDB_DIRPATH
-from studio.app.optinist.core.expdb.batch_const import PROC_FILE_EXT
-from studio.app.optinist.core.expdb.expdb_data import ExpDbPathIds
-from studio.app.optinist.core.expdb.proc_file_data import ProcFile
+from studio.app.optinist.core.expdb.proc_file_data import ProcFile, ProcFileUtils
 
 
 class ProcFileReader:
@@ -17,39 +12,15 @@ class ProcFileReader:
 
     @classmethod
     def read(cls, exp_id: str) -> ProcFile:
-        return cls.read_from_path(cls.get_proc_file_path(exp_id))
+        return cls.read_from_path(ProcFileUtils.get_proc_file_path(exp_id))
 
     @classmethod
     def read_from_path(cls, filepath: str) -> ProcFile:
         config = ConfigReader.read(filepath)
         assert config, f"Invalid config yaml file: [{filepath}] [{config}]"
-        return cls._create_proc_file(config)
-
-    @classmethod
-    def get_proc_file_path(cls, exp_id: str) -> str:
-        exp_ids = ExpDbPathIds(exp_id=exp_id)
-        path = join_filepath(
-            [EXPDB_DIRPATH.EXPDB_DIR, exp_ids.subject_id, f"{exp_id}{PROC_FILE_EXT}"]
-        )
-        return path
-
-    @classmethod
-    def get_proc_file_wild_path(cls) -> str:
-        path = f"{EXPDB_DIRPATH.EXPDB_DIR}/*/*{PROC_FILE_EXT}"
-        return path
-
-    @classmethod
-    def _create_proc_file(cls, config: dict) -> ProcFile:
-        return ProcFile(
-            command=config.get("command"),
-            roi_method=config.get("roi_method"),
-        )
+        return ProcFileUtils.create_proc_file(config)
 
     @classmethod
     def find_proc_files(cls):
-        target_proc_files = sorted(glob.glob(cls.get_proc_file_wild_path()))
+        target_proc_files = sorted(glob.glob(ProcFileUtils.get_proc_file_wild_path()))
         return target_proc_files
-
-    @classmethod
-    def parse_exp_id_from_path(cls, file_path: str) -> str:
-        return os.path.basename(file_path).split(".", 1)[0]

--- a/studio/app/optinist/core/expdb/proc_file_reader.py
+++ b/studio/app/optinist/core/expdb/proc_file_reader.py
@@ -1,0 +1,55 @@
+import glob
+import os
+
+from studio.app.common.core.utils.config_handler import ConfigReader
+from studio.app.common.core.utils.filepath_creater import join_filepath
+from studio.app.expdb_dir_path import EXPDB_DIRPATH
+from studio.app.optinist.core.expdb.batch_const import PROC_FILE_EXT
+from studio.app.optinist.core.expdb.expdb_data import ExpDbPathIds
+from studio.app.optinist.core.expdb.proc_file_data import ProcFile
+
+
+class ProcFileReader:
+    """
+    Reader class of "proc file"
+      (command file that controls the execution of expdb_batch batch)
+    """
+
+    @classmethod
+    def read(cls, exp_id: str) -> ProcFile:
+        return cls.read_from_path(cls.get_proc_file_path(exp_id))
+
+    @classmethod
+    def read_from_path(cls, filepath: str) -> ProcFile:
+        config = ConfigReader.read(filepath)
+        assert config, f"Invalid config yaml file: [{filepath}] [{config}]"
+        return cls._create_proc_file(config)
+
+    @classmethod
+    def get_proc_file_path(cls, exp_id: str) -> str:
+        exp_ids = ExpDbPathIds(exp_id=exp_id)
+        path = join_filepath(
+            [EXPDB_DIRPATH.EXPDB_DIR, exp_ids.subject_id, f"{exp_id}{PROC_FILE_EXT}"]
+        )
+        return path
+
+    @classmethod
+    def get_proc_file_wild_path(cls) -> str:
+        path = f"{EXPDB_DIRPATH.EXPDB_DIR}/*/*{PROC_FILE_EXT}"
+        return path
+
+    @classmethod
+    def _create_proc_file(cls, config: dict) -> ProcFile:
+        return ProcFile(
+            command=config.get("command"),
+            roi_method=config.get("roi_method"),
+        )
+
+    @classmethod
+    def find_proc_files(cls):
+        target_proc_files = sorted(glob.glob(cls.get_proc_file_wild_path()))
+        return target_proc_files
+
+    @classmethod
+    def parse_exp_id_from_path(cls, file_path: str) -> str:
+        return os.path.basename(file_path).split(".", 1)[0]

--- a/studio/app/optinist/core/expdb/proc_file_writer.py
+++ b/studio/app/optinist/core/expdb/proc_file_writer.py
@@ -1,0 +1,55 @@
+import datetime
+import os
+import pathlib
+from dataclasses import asdict
+
+from studio.app.common.core.utils.config_handler import ConfigWriter
+from studio.app.optinist.core.expdb.proc_file_data import ProcFile, ProcFileUtils
+
+
+class ProcFileWriter:
+    """
+    Writer class of "proc file"
+      (command file that controls the execution of expdb_batch batch)
+    """
+
+    @classmethod
+    def write(cls, exp_id: str, proc_file: ProcFile):
+        cls.write_to_path(ProcFileUtils.get_proc_file_path(exp_id), proc_file)
+
+    @classmethod
+    def write_to_path(cls, filepath: str, proc_file: ProcFile):
+        ConfigWriter.write(
+            dirname=os.path.dirname(filepath),
+            filename=os.path.basename(filepath),
+            config=asdict(proc_file),
+        )
+
+    @classmethod
+    def backup_proc_file(cls, src_proc_path: str, is_success: bool):
+        # Create backup file path
+        if is_success:
+            renamed_proc_path = src_proc_path + ".done"
+        else:
+            renamed_proc_path = src_proc_path + ".error"
+
+        # Rename the old proc file if it exists
+        if os.path.isfile(renamed_proc_path):
+            ps = pathlib.Path(renamed_proc_path).stat()
+            st_mtime = datetime.datetime.fromtimestamp(ps.st_mtime).strftime(
+                "%Y%m%d%H%M%S"
+            )
+            os.rename(renamed_proc_path, renamed_proc_path + "." + st_mtime)
+
+        # Apply rename
+        os.rename(src_proc_path, renamed_proc_path)
+
+    @classmethod
+    def write_and_backup_proc_file(
+        cls, filepath: str, proc_file: ProcFile, is_success: bool
+    ):
+        """
+        Execute `write_to_path` and `backup_proc_file` together.
+        """
+        cls.write_to_path(filepath, proc_file)
+        cls.backup_proc_file(filepath, is_success)

--- a/studio/app/optinist/core/expdb/workflow_expdb_batch_runner.py
+++ b/studio/app/optinist/core/expdb/workflow_expdb_batch_runner.py
@@ -16,13 +16,9 @@ from studio.app.optinist.core.expdb.batch_const import (
     ProcessCommand,
     SupportedRoiMethod,
 )
-from studio.app.optinist.core.expdb.expdb_data import (
-    BatchProcFile,
-    BatchProcFileExt,
-    ExpDbPathIdsUtil,
-    ProcessResult,
-)
+from studio.app.optinist.core.expdb.expdb_data import ExpDbPathIdsUtil, ProcessResult
 from studio.app.optinist.core.expdb.expdb_validator import ExpDbValidator
+from studio.app.optinist.core.expdb.proc_file_data import ProcFile, ProcFileExt
 
 logger = AppLogger.get_logger()
 
@@ -165,28 +161,28 @@ class WorkflowExpdbBatchRunner:
         shutil.copy(src_workflow_yaml_path, dest_workflow_yaml_path)
 
         # ------------------------------------------------------------
-        # Write .proc file
+        # Write batch proc file
         # ------------------------------------------------------------
 
         # Generate .proc file contents
-        proc_file = BatchProcFileExt(
+        proc_file = ProcFileExt(
             exp_id=exp_id,
             command=ProcessCommand.REGIST.value,
             roi_method=roi_method.value,
         )
 
-        logger.info(f"Generate .proc for batch [{proc_file}]")
+        logger.info(f"Generate batch proc file [{proc_file}]")
 
-        # Write .proc file
+        # Write proc file
         # Check the status to see if batch processing is running (check the lock file).
         # @see studio.app.optinist.core.expdb.batch_runner.__process_preprocess
         proc_lock_file = None
         try:
             proc_lock_file = lockfile.LockFile(LOCKFILE_NAME)
 
-            # Write .proc file
+            # Write proc file
             with open(proc_file.file_path, "w") as f:
-                store_proc_file = BatchProcFile(
+                store_proc_file = ProcFile(
                     command=proc_file.command, roi_method=proc_file.roi_method
                 )
                 yaml.dump(asdict(store_proc_file), f)

--- a/studio/app/optinist/core/expdb/workflow_expdb_batch_runner.py
+++ b/studio/app/optinist/core/expdb/workflow_expdb_batch_runner.py
@@ -1,7 +1,5 @@
 import shutil
-from dataclasses import asdict
 
-import yaml
 from fastapi import BackgroundTasks, HTTPException, status
 from zc import lockfile
 
@@ -18,7 +16,8 @@ from studio.app.optinist.core.expdb.batch_const import (
 )
 from studio.app.optinist.core.expdb.expdb_data import ExpDbPathIdsUtil, ProcessResult
 from studio.app.optinist.core.expdb.expdb_validator import ExpDbValidator
-from studio.app.optinist.core.expdb.proc_file_data import ProcFile, ProcFileExt
+from studio.app.optinist.core.expdb.proc_file_data import ProcFile
+from studio.app.optinist.core.expdb.proc_file_writer import ProcFileWriter
 
 logger = AppLogger.get_logger()
 
@@ -164,9 +163,8 @@ class WorkflowExpdbBatchRunner:
         # Write batch proc file
         # ------------------------------------------------------------
 
-        # Generate .proc file contents
-        proc_file = ProcFileExt(
-            exp_id=exp_id,
+        # Generate proc file contents
+        proc_file = ProcFile(
             command=ProcessCommand.REGIST.value,
             roi_method=roi_method.value,
         )
@@ -181,11 +179,7 @@ class WorkflowExpdbBatchRunner:
             proc_lock_file = lockfile.LockFile(LOCKFILE_NAME)
 
             # Write proc file
-            with open(proc_file.file_path, "w") as f:
-                store_proc_file = ProcFile(
-                    command=proc_file.command, roi_method=proc_file.roi_method
-                )
-                yaml.dump(asdict(store_proc_file), f)
+            ProcFileWriter.write(exp_id, proc_file)
 
         except lockfile.LockError as e:
             err_message = (

--- a/studio/tests/app/optinist/core/expdb/test_proc_file_reader_writer.py
+++ b/studio/tests/app/optinist/core/expdb/test_proc_file_reader_writer.py
@@ -1,0 +1,35 @@
+import os
+
+from studio.app.optinist.core.expdb.batch_const import ProcessCommand
+from studio.app.optinist.core.expdb.proc_file_data import ProcFile, ProcFileUtils
+from studio.app.optinist.core.expdb.proc_file_reader import ProcFileReader
+from studio.app.optinist.core.expdb.proc_file_writer import ProcFileWriter
+
+exp_id = "DMY0001_ori001"
+
+
+def test_proc_file_reader_writer():
+    proc_file_path = ProcFileUtils.get_proc_file_path(exp_id)
+
+    try:
+        # ----------------------------------------
+        # Writer test
+        # ----------------------------------------
+
+        proc_file = ProcFile(command=ProcessCommand.REGIST.value)
+        ProcFileWriter.write(exp_id, proc_file)
+        assert os.path.exists(proc_file_path)
+
+        # ----------------------------------------
+        # Reader test
+        # ----------------------------------------
+
+        proc_file = ProcFileReader.read(exp_id)
+        assert proc_file
+
+        proc_file_paths = ProcFileReader.find_proc_files()
+        assert proc_file_paths
+
+    finally:
+        if os.path.exists(proc_file_path):
+            os.remove(proc_file_path)


### PR DESCRIPTION
### Content

In anticipation of future scalability, I have replaced the method of manipulating proc files with raw yaml with a method of manipulating them with dedicated modules (such as reader and writer).

### Testcase

Existing processes are operating normally with the same specifications as before the fix.

- [x] Batch processing is successful.
- Each proc file is generated properly.
  - [x] At start: `{exp_id}.proc`
  - [x] At end (success): `{exp_id}.proc.done`
  - [x] At end (error): `{exp_id}.proc.error`
  - [x] If a previous proc file exists, it must be renamed appropriately.: `{exp_id}.proc.(done|error).{timestamp}`
