### PR TITLE
suite2p_preprocessing.yaml is separated into development and production

### DIFF
--- a/studio/app/optinist/wrappers/suite2p/params/suite2p_preprocessing.production.yaml
+++ b/studio/app/optinist/wrappers/suite2p/params/suite2p_preprocessing.production.yaml
@@ -37,7 +37,7 @@ cell_detection:
   max_overlap: 0.75      # cells with more overlap than this get removed during triage before refinement
   nbinned: 5000          # max number of binned frames for cell detection
   spatial_scale: 0       # 0: multi-scale; 1: 6 pixels 2: 12 pixels 3: 24 pixels 4: 48 pixels
-  threshold_scaling: 6.0 # adjust the automatically determined threshold by this scalar multiplier
+  threshold_scaling: 1.0 # adjust the automatically determined threshold by this scalar multiplier
   max_iterations: 20     # maximum number of iterations to do cell detection
 
 # ----------------------------------------


### PR DESCRIPTION
### Content

`params/suite2p_preprocessing.yaml` is separated into development (lightweight version) and production

#### Purpose

When a large number of ROIs are detected, the number of subsequent processing steps (such as cell image generation) increases, resulting in longer processing times.

In response to the above specifications, this PR provides suite2p parameters for developers to reduce the number of ROIs detected (reduce processing load).

Parameters that are likely to be applicable to controlling the number of ROIs detected
- max_iterations: Maximum number of iterations for ROI detection
- threshold_scaling: ROI detection rigor

#### Verification Results

- max_iterations (default:20)
  - No effect (tested in the range 1-20)
- threshold_scaling (default:1.0)
  - This parameter appears to be effective
  - Results
    - Test data
      - M000000_ori001.nd2 (512 x 512 x 320 frames)
    - Log
      ```
      // threshold_scaling=1.0 (default)
      suite2p_preprocessing():270 - Detected 4747 ROIs
      suite2p_preprocessing():560 - Detected 1572 cells, 3175 non-cells
      
      // threshold_scaling=5.0
      suite2p_preprocessing():270 - Detected 83 ROIs
      suite2p_preprocessing():560 - Detected 83 cells, 0 non-cells
      
      // threshold_scaling=6.0
      suite2p_preprocessing():270 - Detected 23 ROIs
      suite2p_preprocessing():560 - Detected 23 cells, 0 non-cells
      
      // threshold_scaling=7.0
      suite2p_preprocessing():270 - Detected 8 ROIs
      suite2p_preprocessing():560 - Detected 8 cells, 0 non-cells
      
      // threshold_scaling=8.0
      suite2p_preprocessing():270 - Detected 2 ROIs
      suite2p_preprocessing():560 - Detected 2 cells, 0 non-cells
      ```
  - Based on the test results, set `threshold_scaling=6.0` for development.


### Testcase

- [x] Test suite2p_preprocessing.yaml (`threshold_scaling=6.0`)
  - Applying the contents of suite2p_preprocessing.yaml to workflow.yaml will produce results equivalent to those shown above (processing will generally take a few minutes).
- [x] Test suite2p_preprocessing.production.yaml (`threshold_scaling=1.0`)
  - Applying the contents of suite2p_preprocessing.production.yaml to workflow.yaml will produce results equivalent to those shown above (although this will require a long processing time (e.g., over an hour)).

### Others

When releasing the system to the production environment, be sure to follow the procedure of **"rename suite2p_preprocessing.production.yaml to suite2p_preprocessing.yaml and deploy."** (Do not release in the development version.)
