### PR TITLE
Refactoring Feature/conda-env-switch branch (conda env and roi_method switching) 

### DIFF
--- a/cron/run_expdb_batch_script.sh
+++ b/cron/run_expdb_batch_script.sh
@@ -15,64 +15,27 @@ proc_files=$(find "$DATASET_DIR" -maxdepth 2 -name "$PROC_FILE_PATTERN" -type f)
 if [ -z "$proc_files" ]; then
   echo "No proc files found."
   exit
+else
+  echo "Proc files found. [$proc_files]"
 fi
 
-echo "Processing datasets by ROI method..."
-
-# Function to extract roi_method from .proc file
-get_roi_method() {
-  local proc_file=$1
-  # Use Python to parse YAML and extract roi_method
-  python3 -c "
-import yaml
-import sys
-import os
-
-# Add studio path for imports
-sys.path.insert(0, os.path.abspath('.'))
-
-try:
-    from studio.app.optinist.core.expdb.batch_const import SupportedRoiMethod
-    default_roi = SupportedRoiMethod.CAIMAN.value
-except ImportError:
-    default_roi = 'caiman'  # Fallback if import fails
-
-try:
-    with open('$proc_file') as f:
-        config = yaml.safe_load(f)
-        roi_method = config.get('roi_method', default_roi)
-        print(roi_method)
-except Exception as e:
-    print(default_roi)  # Default to caiman on error
-    sys.stderr.write(f'Warning: Could not parse $proc_file: {e}\n')
-"
-}
-
-# Group proc files by roi_method
-caiman_files=""
-suite2p_files=""
-
-for proc_file in $proc_files; do
-  roi_method=$(get_roi_method "$proc_file")
-  echo "File: $proc_file -> roi_method: $roi_method"
-
-  if [ "$roi_method" = "suite2p" ]; then  # SupportedRoiMethod.SUITE2P.value
-    suite2p_files="$suite2p_files $proc_file"
-  else  # Defaults to caiman (SupportedRoiMethod.CAIMAN.value)
-    caiman_files="$caiman_files $proc_file"
-  fi
-done
+# ------------------------------------------------------------
+# Start batch process
+#
+# NOTE:
+# - If .proc files exist, launch batch runs for all roi methods (caiman, suite2p, ...).
+# - The batch run module automatically determines
+#   which roi method each proc file corresponds to based on the conda environment.
+# ------------------------------------------------------------
 
 # Process CaImAn datasets
-if [ -n "$caiman_files" ]; then
-  echo "Processing CaImAn datasets: $caiman_files"
-  conda activate expdb_batch_caiman && \
-    python run_expdb_batch.py -o 1 -p 5 --filter-roi-method caiman
-fi
+echo "Processing CaImAn datasets"
+conda activate expdb_batch_caiman && \
+  python run_expdb_batch.py -o 1 -p 5
+conda deactivate
 
 # Process Suite2p datasets
-if [ -n "$suite2p_files" ]; then
-  echo "Processing Suite2p datasets: $suite2p_files"
-  conda activate expdb_batch_suite2p && \
-    python run_expdb_batch.py -o 1 -p 5 --filter-roi-method suite2p
-fi
+echo "Processing Suite2p datasets"
+conda activate expdb_batch_suite2p && \
+  python run_expdb_batch.py -o 1 -p 5
+conda deactivate

--- a/run_expdb_batch.py
+++ b/run_expdb_batch.py
@@ -4,9 +4,7 @@ import argparse
 def main(args):
     from studio.app.optinist.core.expdb.batch_runner import ExpDbBatchRunner
 
-    runner = ExpDbBatchRunner(
-        args.org_id, args.parallel_workers, filter_roi_method=args.filter_roi_method
-    )
+    runner = ExpDbBatchRunner(args.org_id, args.parallel_workers)
     runner.process()
 
 
@@ -21,13 +19,6 @@ if __name__ == "__main__":
         type=int,
         default=1,
         help="Number of parallel processes (default: 1)",
-    )
-    parser.add_argument(
-        "--filter-roi-method",
-        type=str,
-        choices=["caiman", "suite2p"],
-        default=None,
-        help="Only process datasets with this roi_method (optional)",
     )
 
     from studio.app.optinist.microscopes.ND2Reader import ND2Reader

--- a/studio/app/optinist/core/expdb/batch_runner.py
+++ b/studio/app/optinist/core/expdb/batch_runner.py
@@ -28,6 +28,7 @@ from studio.app.optinist.core.expdb.crud_expdb import (
     update_experiment,
 )
 from studio.app.optinist.core.expdb.expdb_data import ProcessResult
+from studio.app.optinist.core.expdb.expdb_validator import ExpDbEnviromentValidator
 from studio.app.optinist.core.expdb.proc_file_data import (
     ProcFile,
     ProcFilePath,
@@ -49,13 +50,14 @@ class ExpDbBatchRunner:
         self,
         organization_id: int,
         parallel_workers: int = 1,
-        filter_roi_method: str = None,
     ):
         self.start_time = datetime.datetime.now()
         self.__init_logger()
         self.org_id = organization_id
         self.parallel_workers = parallel_workers
-        self.filter_roi_method = filter_roi_method
+        self.available_roi_methods = (
+            ExpDbEnviromentValidator.check_available_roi_methods()
+        )
 
     def __init_logger(self):
         logging_config = yaml.safe_load(
@@ -176,23 +178,9 @@ class ExpDbBatchRunner:
 
         # 処理対象datasets検索
         self.logger_.info("proc files search path: %s", EXPDB_DIRPATH.EXPDB_DIR)
-        found_proc_files = ProcFileReader.find_proc_files()
-
-        # Filter by roi_method if specified
-        if self.filter_roi_method:
-            self.logger_.info(
-                f"Filtering datasets by roi_method: {self.filter_roi_method}"
-            )
-            filtered_files = []
-            for proc_file_path in found_proc_files:
-                if proc_file_path.proc_data.roi_method == self.filter_roi_method:
-                    filtered_files.append(proc_file_path)
-                    self.logger_.info(f"Including proc file: {proc_file_path}")
-                else:
-                    self.logger_.info(f"Skipping proc file: {proc_file_path}")
-            target_proc_files = filtered_files
-        else:
-            target_proc_files = found_proc_files
+        target_proc_files = ProcFileReader.find_proc_files(
+            filter_roi_methods=self.available_roi_methods
+        )
 
         # 処理対象datasetsが存在しない場合は、ここで処理終了（return）
         if len(target_proc_files) == 0:

--- a/studio/app/optinist/core/expdb/batch_runner.py
+++ b/studio/app/optinist/core/expdb/batch_runner.py
@@ -172,7 +172,7 @@ class ExpDbBatchRunner:
 
         # 処理対象datasets検索
         self.logger_.info("proc files search path: %s", EXPDB_DIRPATH.EXPDB_DIR)
-        target_proc_files = ProcFileReader.find_proc_files()
+        found_proc_files = ProcFileReader.find_proc_files()
 
         # Filter by roi_method if specified
         if self.filter_roi_method:
@@ -180,25 +180,21 @@ class ExpDbBatchRunner:
                 f"Filtering datasets by roi_method: {self.filter_roi_method}"
             )
             filtered_files = []
-            for proc_file_path in target_proc_files:
-                try:
-                    proc_file = ProcFileReader.read_from_path(proc_file_path)
-                    roi_method = proc_file.roi_method or SupportedRoiMethod.CAIMAN.value
-                    if roi_method == self.filter_roi_method:
-                        filtered_files.append(proc_file_path)
-                        self.logger_.info(
-                            f"Including: {proc_file_path} (roi_method={roi_method})"
-                        )
-                    else:
-                        self.logger_.info(
-                            f"Skipping: {proc_file_path} (roi_method={roi_method})"
-                        )
-                except Exception as e:
-                    # Skip corrupted files entirely - they'll be retried on next run
-                    self.logger_.error(
-                        f"Could not read {proc_file_path}: {e}, skipping"
+            for proc_file_path in found_proc_files:
+                # Set default roi_method value
+                if proc_file_path.proc_data.roi_method is None:
+                    proc_file_path.proc_data.roi_method = (
+                        SupportedRoiMethod.CAIMAN.value
                     )
+
+                if proc_file_path.proc_data.roi_method == self.filter_roi_method:
+                    filtered_files.append(proc_file_path)
+                    self.logger_.info(f"Including proc file: {proc_file_path}")
+                else:
+                    self.logger_.info(f"Skipping proc file: {proc_file_path}")
             target_proc_files = filtered_files
+        else:
+            target_proc_files = found_proc_files
 
         # 処理対象datasetsが存在しない場合は、ここで処理終了（return）
         if len(target_proc_files) == 0:
@@ -221,7 +217,7 @@ class ExpDbBatchRunner:
             futures = [
                 executor.submit(
                     ExpDbBatchConcurrentProcess.process_single_dataset_entrypoint,
-                    proc_file_path=proc_file_path,
+                    proc_file_path=proc_file_path.path,
                     org_id=self.org_id,
                     start_time=self.start_time,
                     logger_name=__class__.LOGGER_NAME,

--- a/studio/app/optinist/core/expdb/batch_runner.py
+++ b/studio/app/optinist/core/expdb/batch_runner.py
@@ -28,7 +28,11 @@ from studio.app.optinist.core.expdb.crud_expdb import (
     update_experiment,
 )
 from studio.app.optinist.core.expdb.expdb_data import ProcessResult
-from studio.app.optinist.core.expdb.proc_file_data import ProcFile, ProcFileUtils
+from studio.app.optinist.core.expdb.proc_file_data import (
+    ProcFile,
+    ProcFilePath,
+    ProcFileUtils,
+)
 from studio.app.optinist.core.expdb.proc_file_reader import ProcFileReader
 from studio.app.optinist.core.expdb.proc_file_writer import ProcFileWriter
 from studio.app.optinist.schemas.expdb.experiment import (
@@ -181,12 +185,6 @@ class ExpDbBatchRunner:
             )
             filtered_files = []
             for proc_file_path in found_proc_files:
-                # Set default roi_method value
-                if proc_file_path.proc_data.roi_method is None:
-                    proc_file_path.proc_data.roi_method = (
-                        SupportedRoiMethod.CAIMAN.value
-                    )
-
                 if proc_file_path.proc_data.roi_method == self.filter_roi_method:
                     filtered_files.append(proc_file_path)
                     self.logger_.info(f"Including proc file: {proc_file_path}")
@@ -217,7 +215,7 @@ class ExpDbBatchRunner:
             futures = [
                 executor.submit(
                     ExpDbBatchConcurrentProcess.process_single_dataset_entrypoint,
-                    proc_file_path=proc_file_path.path,
+                    proc_file_path=proc_file_path,
                     org_id=self.org_id,
                     start_time=self.start_time,
                     logger_name=__class__.LOGGER_NAME,
@@ -312,7 +310,7 @@ class ExpDbBatchConcurrentProcess:
     @classmethod
     def process_single_dataset_entrypoint(
         cls,
-        proc_file_path: str,
+        proc_file_path: ProcFilePath,
         org_id: int,
         start_time: datetime.datetime,
         logger_name: str,
@@ -329,16 +327,16 @@ class ExpDbBatchConcurrentProcess:
     @stopwatch(callback=dataset_process_stopwatch_callback)
     def process_single_dataset(
         cls,
-        proc_file_path: str,
+        proc_file_path: ProcFilePath,
         org_id: int,
         start_time: datetime.datetime,
         logger_name: str,
     ) -> dict:
-        exp_id = ProcFileUtils.parse_exp_id_from_path(proc_file_path)
+        exp_id = ProcFileUtils.parse_exp_id_from_path(proc_file_path.path)
         logger = cls.__init_process_logger(exp_id)
         logger.info(
             f"Process {os.getpid()} starting to "
-            f"process exp_id: {exp_id}, proc_file_path: {proc_file_path}"
+            f"process exp_id: {exp_id}, proc_file_path: {proc_file_path.path}"
         )
 
         error = None
@@ -346,23 +344,29 @@ class ExpDbBatchConcurrentProcess:
         result = {"success": False, "exp_id": exp_id}
 
         try:
-            # Read proc file
-            proc_file = ProcFileReader.read_from_path(proc_file_path)
-
             # コマンド判定
-            command = proc_file.command
+            command = proc_file_path.proc_data.command
 
             if command == ProcessCommand.REGIST.value:
                 cls.process_dataset_registration(
-                    exp_id=exp_id, org_id=org_id, logger=logger
+                    exp_id=exp_id,
+                    org_id=org_id,
+                    roi_method=SupportedRoiMethod(proc_file_path.proc_data.roi_method),
+                    logger=logger,
                 )
             elif command == ProcessCommand.REGIST_METADATA.value:
                 cls.process_dataset_metadata_registration(
-                    exp_id=exp_id, org_id=org_id, logger=logger
+                    exp_id=exp_id,
+                    org_id=org_id,
+                    roi_method=SupportedRoiMethod(proc_file_path.proc_data.roi_method),
+                    logger=logger,
                 )
             elif command == ProcessCommand.DELETE.value:
                 cls.process_dataset_deletion(
-                    exp_id=exp_id, org_id=org_id, logger=logger
+                    exp_id=exp_id,
+                    org_id=org_id,
+                    roi_method=SupportedRoiMethod(proc_file_path.proc_data.roi_method),
+                    logger=logger,
                 )
             else:
                 raise ValueError(
@@ -389,7 +393,7 @@ class ExpDbBatchConcurrentProcess:
     @classmethod
     @stopwatch(callback=dataset_process_stopwatch_callback)
     def process_dataset_registration(
-        cls, exp_id: str, org_id: int, logger: logging
+        cls, exp_id: str, org_id: int, roi_method: SupportedRoiMethod, logger: logging
     ) -> bool:
         """
         Dataset登録処理
@@ -397,7 +401,7 @@ class ExpDbBatchConcurrentProcess:
 
         logger.info("process dataset registration: %s", exp_id)
 
-        expdb_batch = ExpDbBatch(exp_id, org_id)
+        expdb_batch = ExpDbBatch(exp_id, org_id, roi_method)
 
         # CleanUp database records
         with concurrent_db_session_scope() as db:
@@ -462,7 +466,7 @@ class ExpDbBatchConcurrentProcess:
     @classmethod
     @stopwatch(callback=dataset_process_stopwatch_callback)
     def process_dataset_metadata_registration(
-        cls, exp_id: str, org_id: int, logger: logging
+        cls, exp_id: str, org_id: int, roi_method: SupportedRoiMethod, logger: logging
     ) -> bool:
         """
         Metadata 登録処理
@@ -470,7 +474,7 @@ class ExpDbBatchConcurrentProcess:
 
         logger.info("process dataset metadata registration: %s", exp_id)
 
-        expdb_batch = ExpDbBatch(exp_id, org_id)
+        expdb_batch = ExpDbBatch(exp_id, org_id, roi_method)
 
         with concurrent_db_session_scope() as db:
             try:
@@ -500,7 +504,7 @@ class ExpDbBatchConcurrentProcess:
     @classmethod
     @stopwatch(callback=dataset_process_stopwatch_callback)
     def process_dataset_deletion(
-        cls, exp_id: str, org_id: int, logger: logging
+        cls, exp_id: str, org_id: int, roi_method: SupportedRoiMethod, logger: logging
     ) -> bool:
         """
         Dataset削除処理
@@ -508,7 +512,7 @@ class ExpDbBatchConcurrentProcess:
 
         logger.info("process dataset registration: %s", exp_id)
 
-        expdb_batch = ExpDbBatch(exp_id, org_id)
+        expdb_batch = ExpDbBatch(exp_id, org_id, roi_method)
 
         with concurrent_db_session_scope() as db:
             expdb_batch.cleanup_exp_record(db)
@@ -518,7 +522,7 @@ class ExpDbBatchConcurrentProcess:
     @classmethod
     def process_dataset_postprocess(
         cls,
-        proc_file_path: str,
+        proc_file_path: ProcFilePath,
         command: str,
         start_time: datetime.datetime,
         error: Exception = None,
@@ -535,8 +539,7 @@ class ExpDbBatchConcurrentProcess:
         # Read existing proc file to preserve roi_method
         existing_roi_method = None
         try:
-            existing_proc_file = ProcFileReader.read_from_path(proc_file_path)
-            existing_roi_method = existing_proc_file.roi_method
+            existing_roi_method = proc_file_path.proc_data.roi_method
         except Exception:
             # If we can't read the file, roi_method will be None
             pass
@@ -566,5 +569,5 @@ class ExpDbBatchConcurrentProcess:
 
         # Write and rename/backup proc file
         ProcFileWriter.write_and_backup_proc_file(
-            proc_file_path, result_proc, is_success
+            proc_file_path.path, result_proc, is_success
         )

--- a/studio/app/optinist/core/expdb/batch_unit.py
+++ b/studio/app/optinist/core/expdb/batch_unit.py
@@ -130,10 +130,13 @@ class ExpDbBatch:
     #   ExpDbBatchConcurrentProcess.LOGGER_NAME.
     LOGGER_NAME = "batch_process_logger"
 
-    def __init__(self, exp_id: str, org_id: int) -> None:
+    def __init__(
+        self, exp_id: str, org_id: int, roi_method: SupportedRoiMethod
+    ) -> None:
         self.logger_ = logging.getLogger(__class__.LOGGER_NAME)
         self.exp_id = exp_id
         self.org_id = org_id
+        self.roi_method = roi_method
 
         self.raw_path = ExpDbBatchPath(self.exp_id, is_raw=True)
         self.pub_path = ExpDbBatchPath(self.exp_id)
@@ -141,7 +144,7 @@ class ExpDbBatch:
         self.nwbfile = {}
 
         self.workflow_config_reader = ExpDbWorkflowConfigReader(
-            self.logger_, self.exp_id
+            self.logger_, self.exp_id, self.roi_method
         )
 
         self._configure_matplotlib()
@@ -158,40 +161,6 @@ class ExpDbBatch:
         circular_patterns = ["_ori", "_OF-PRC-", "_dot"]
         is_circular_data = any(pattern in data_name for pattern in circular_patterns)
         return is_circular_data
-
-    def _get_roi_method(self) -> str:
-        """
-        Determine which ROI detection method to use by reading from .proc file.
-        Defaults to 'caiman' if roi_method is not specified or cannot be read.
-
-        Returns:
-            str: Either 'caiman' or 'suite2p'
-        """
-        from studio.app.optinist.core.expdb.proc_file_data import ProcFileUtils
-        from studio.app.optinist.core.expdb.proc_file_reader import ProcFileReader
-
-        proc_file_path = ProcFileUtils.get_proc_file_path(self.exp_id)
-
-        try:
-            proc_file = ProcFileReader.read_from_path(proc_file_path)
-            roi_method = proc_file.roi_method or SupportedRoiMethod.CAIMAN.value
-
-            supported_methods = [m.value for m in SupportedRoiMethod]
-            if roi_method in supported_methods:
-                self.logger_.info(f"Using ROI method from .proc file: {roi_method}")
-                return roi_method
-            else:
-                self.logger_.warning(
-                    f"Invalid roi_method '{roi_method}' in .proc file, "
-                    f"defaulting to {SupportedRoiMethod.CAIMAN.value}"
-                )
-                return SupportedRoiMethod.CAIMAN.value
-        except Exception as e:
-            self.logger_.info(
-                f"Could not read roi_method from .proc file ({proc_file_path}): {e}, "
-                f"defaulting to {SupportedRoiMethod.CAIMAN.value}"
-            )
-            return SupportedRoiMethod.CAIMAN.value
 
     @stopwatch(callback=__stopwatch_callback)
     def cleanup_exp_record(self, db: Session):
@@ -267,8 +236,7 @@ class ExpDbBatch:
         )
 
         # Get parameters for ROI processing based on detected ROI method
-        roi_method = self._get_roi_method()
-        node_name = SupportedRoiMethod.get_node_name_from_roi_method(roi_method)
+        node_name = SupportedRoiMethod.get_node_name_from_roi_method(self.roi_method)
         self.logger_.info(f"Using ROI parameters from node: {node_name}")
         params = self.workflow_config_reader.get_node_params_or_default(node_name)
         roi_thr = params.get("roi_thr", 0.9)
@@ -443,17 +411,16 @@ class ExpDbBatch:
             Dictionary with processed_data (ExpDbData) and other outputs
             from the selected cell detection method
         """
-        roi_method = self._get_roi_method()
-
-        if roi_method == SupportedRoiMethod.SUITE2P.value:
+        if self.roi_method == SupportedRoiMethod.SUITE2P:
             self.logger_.info("Using Suite2p for cell detection")
             return self.cell_detection_suite2p(stack)
-        elif roi_method == SupportedRoiMethod.CAIMAN.value:
+        elif self.roi_method == SupportedRoiMethod.CAIMAN:
             self.logger_.info("Using CaImAn CNMF for cell detection")
             return self.cell_detection_cnmf(stack)
         else:  # Default to caiman
             self.logger_.info(
-                f"Unknown roi_method '{roi_method}', " f"defaulting to CaImAn CNMF"
+                f"Unknown roi_method '{self.roi_method.value}', "
+                f"defaulting to CaImAn CNMF"
             )
             return self.cell_detection_cnmf(stack)
 
@@ -727,9 +694,12 @@ class ExpDbWorkflowConfigReader:
       (workflow.yaml contains parameters for the node that executes the batch, etc.)
     """
 
-    def __init__(self, logger: logging.Logger, exp_id: str) -> None:
+    def __init__(
+        self, logger: logging.Logger, exp_id: str, roi_method: SupportedRoiMethod
+    ) -> None:
         self.logger_ = logger
         self.exp_id = exp_id
+        self.roi_method = roi_method
 
         # Load workflow config if it exists (for GUI-configured parameters)
         self.workflow_config = self._load_workflow_config()
@@ -768,9 +738,18 @@ class ExpDbWorkflowConfigReader:
                 return None
 
             # Extract and validate ROI method from workflow
-            roi_method = ExpDbValidator.validate_batch_roi_method(config)
-            if roi_method:
-                self.logger_.info(f"Workflow specifies ROI method: {roi_method.value}")
+            workflow_roi_method = ExpDbValidator.validate_batch_roi_method(config)
+            if workflow_roi_method:
+                if workflow_roi_method == self.roi_method:
+                    self.logger_.info(
+                        f"Workflow specifies ROI method: {workflow_roi_method.value}"
+                    )
+                else:
+                    self.logger_.warning(
+                        "ROI method in the workflow and proc file does not match.: "
+                        f"[workflow roi_method: {workflow_roi_method.value}] "
+                        f"[proc file roi_method: {self.roi_method.value}]"
+                    )
             else:
                 self.logger_.warning(
                     "Could not determine ROI method from workflow, "

--- a/studio/app/optinist/core/expdb/expdb_validator.py
+++ b/studio/app/optinist/core/expdb/expdb_validator.py
@@ -1,3 +1,6 @@
+import importlib.util
+from typing import List
+
 from studio.app.common.core.workflow.workflow_reader import WorkflowConfigReader
 from studio.app.common.schemas.workflow import WorkflowConfig
 from studio.app.optinist.core.expdb.batch_const import SupportedRoiMethod
@@ -62,3 +65,19 @@ class ExpDbValidator:
             if roi_node_name
             else None
         )
+
+
+class ExpDbEnviromentValidator:
+    @staticmethod
+    def check_available_roi_methods() -> List[SupportedRoiMethod]:
+        result: List[SupportedRoiMethod] = []
+
+        # Check caiman availability
+        if importlib.util.find_spec("caiman") is not None:
+            result.append(SupportedRoiMethod.CAIMAN)
+
+        # Check suite2p availability
+        if importlib.util.find_spec("suite2p") is not None:
+            result.append(SupportedRoiMethod.SUITE2P)
+
+        return result

--- a/studio/app/optinist/core/expdb/proc_file_data.py
+++ b/studio/app/optinist/core/expdb/proc_file_data.py
@@ -30,6 +30,12 @@ class ProcFile:
     log: Optional[str] = None
 
 
+@dataclass
+class ProcFilePath:
+    path: str
+    proc_data: ProcFile
+
+
 class ProcFileUtils:
     @classmethod
     def parse_exp_id_from_path(cls, file_path: str) -> str:

--- a/studio/app/optinist/core/expdb/proc_file_reader.py
+++ b/studio/app/optinist/core/expdb/proc_file_reader.py
@@ -38,15 +38,23 @@ class ProcFileReader:
 
     @classmethod
     def find_proc_files(
-        cls, type: ProcFileType = ProcFileType.RESERVE
+        cls,
+        type: ProcFileType = ProcFileType.RESERVE,
+        filter_roi_methods: List[SupportedRoiMethod] = None,
     ) -> List[ProcFilePath]:
         found_proc_files = cls.find_proc_files_simple(type)
         result_proc_files = []
 
         for proc_file_path in found_proc_files:
             proc_data = ProcFileReader.read_from_path(proc_file_path)
+            # Set default roi_method value
             if proc_data.roi_method is None:
                 proc_data.roi_method = SupportedRoiMethod.CAIMAN.value
+
+            # Filter whether roi_method is the target of processing
+            currnet_roi_method = SupportedRoiMethod(proc_data.roi_method)
+            if filter_roi_methods and currnet_roi_method not in filter_roi_methods:
+                continue
 
             result_proc_files.append(
                 ProcFilePath(path=proc_file_path, proc_data=proc_data)

--- a/studio/app/optinist/core/expdb/proc_file_reader.py
+++ b/studio/app/optinist/core/expdb/proc_file_reader.py
@@ -1,11 +1,12 @@
 import datetime
 import glob
 from dataclasses import asdict
-from typing import Dict
+from typing import Dict, List
 
 from studio.app.common.core.utils.config_handler import ConfigReader
 from studio.app.optinist.core.expdb.proc_file_data import (
     ProcFile,
+    ProcFilePath,
     ProcFileType,
     ProcFileUtils,
 )
@@ -28,11 +29,26 @@ class ProcFileReader:
         return ProcFileUtils.create_proc_file_data(config)
 
     @classmethod
-    def find_proc_files(cls, type: ProcFileType = ProcFileType.RESERVE):
-        target_proc_files = sorted(
+    def find_proc_files_simple(cls, type: ProcFileType = ProcFileType.RESERVE) -> List:
+        found_proc_files = sorted(
             glob.glob(ProcFileUtils.get_proc_file_wild_path(type))
         )
-        return target_proc_files
+        return found_proc_files
+
+    @classmethod
+    def find_proc_files(
+        cls, type: ProcFileType = ProcFileType.RESERVE
+    ) -> List[ProcFilePath]:
+        found_proc_files = cls.find_proc_files_simple(type)
+        result_proc_files = []
+
+        for proc_file_path in found_proc_files:
+            proc_data = ProcFileReader.read_from_path(proc_file_path)
+            result_proc_files.append(
+                ProcFilePath(path=proc_file_path, proc_data=proc_data)
+            )
+
+        return result_proc_files
 
     @classmethod
     def read_last_processing_log(

--- a/studio/app/optinist/core/expdb/proc_file_reader.py
+++ b/studio/app/optinist/core/expdb/proc_file_reader.py
@@ -4,6 +4,7 @@ from dataclasses import asdict
 from typing import Dict, List
 
 from studio.app.common.core.utils.config_handler import ConfigReader
+from studio.app.optinist.core.expdb.batch_const import SupportedRoiMethod
 from studio.app.optinist.core.expdb.proc_file_data import (
     ProcFile,
     ProcFilePath,
@@ -44,6 +45,9 @@ class ProcFileReader:
 
         for proc_file_path in found_proc_files:
             proc_data = ProcFileReader.read_from_path(proc_file_path)
+            if proc_data.roi_method is None:
+                proc_data.roi_method = SupportedRoiMethod.CAIMAN.value
+
             result_proc_files.append(
                 ProcFilePath(path=proc_file_path, proc_data=proc_data)
             )


### PR DESCRIPTION
## Contents

proc fileで指定された roi_method と 対応する conda env (caiman, suitep2) の切替ロジックを、簡潔な内容に改修した。

### 修正以前の課題

1. 複数の箇所で（.sh, .py に跨り）、roi_method の取得や判定が実施されており、roi_method とconda envの切替のフローの見通しが良くなかった。（テストケースにもロジックをやや反映しづらかった）
2. proc file がbatch module内の複数箇所で随時 file から read されていたことから、データフロー（Inputの出元）が やや曖昧になっていた。

### 修正方針

- Batchコアモジュール
  - batch_runner.py
    - proc file (roi_method) と conda env の対応の判定を、当モジュール側に集約。 結果 Batch起動モジュール 側のロジックを簡素化した。
    - proc file (roi_method) と conda env の対応の判定ロジックを、一般化した
      - 仮に、caiman と suite2p のどちらも存在する env であれば、両者をまとめて一度に処理可能とした
      - また、 caimanのみ、suite2pのみ、というパターンも可能（こちらが現在想定の仕様）
  - batch_unit.py
    - proc file が各箇所で随時 file から read されていたが、データフロー（Inputのsource）が曖昧となるため、その形式は廃止
    - proc fileの情報（roi_method など） は、batch_runner から batch_unit の __init__ へ渡す形式とした（Inputの起点を集約）

- Batch起動モジュール
  - run_expdb_batch.py
    - 外部からの roi_method の指定 (--filter-roi-method) は廃止
  - run_expdb_batch_script.sh
    - proc file (roi_method) と conda env の切替を簡素化
      - 処理簡素化のため、proc file が1件でも存在した場合には、全ての roi method 用の batch (caiman,suite2p) を まとめて起動する形とした
        - proc file が投入されるタイミングは頻繁ではないことから、全ての roi method batch を起動しても、オーバーヘッドは軽微と判断
      - proc file (roi_method) と conda env の対応は、コアモジュール（batch_runner.puy）内で、適切に判定処理される

## Test case

### 前提

- run_expdb_batch において、conda env は base の状態から開始（`conda activate expdb_batch_xxxx` は不要）

### Test case

- [x] 1. caimanのみの処理
  - 手順
    ```sh
    printf "command: regist\nroi_method: caiman" > experiments_datasets/M000000/M000000_ori001.proc
    sh cron/run_expdb_batch_script.sh
    ```
  - 期待結果
    - [x] 対象データセットの処理が正常に完了する（caiman 1件）
- [x] 2. suite2pのみの処理
  - 手順
    ```sh
    printf "command: regist\nroi_method: suite2p" > experiments_datasets/M000000/M000000_ori001.proc
    sh cron/run_expdb_batch_script.sh
    ```
  - 期待結果
    - [x] 対象データセットの処理が正常に完了する（suite2p 1件）
- [x] 3. caimanとcaimanの同時処理
  - 手順
    ```sh
    printf "command: regist\nroi_method: caiman" > experiments_datasets/M000000/M000000_ori001.proc
    printf "command: regist\nroi_method: suite2p" > experiments_datasets/M000001/M000000_ori002.proc
    sh cron/run_expdb_batch_script.sh
    ```
  - 期待結果
    - [x] 対象データセットの処理が正常に完了する（caiman 1件 + suite2p 1件）
