### PR TITLE
Several frontend-related improvements and fixes

### DIFF
--- a/frontend/src/components/Database/DatabaseExperiments.tsx
+++ b/frontend/src/components/Database/DatabaseExperiments.tsx
@@ -380,7 +380,7 @@ const columns = (
     filterable: false,
     sortable: false,
     renderCell: (params: { row: DatabaseType }) => {
-      const inputValue = JSON.stringify(params?.row?.attributes).trim()
+      const inputValue = JSON.stringify(params?.row?.attributes ?? {}).trim()
       const parsedJSON = JSON.parse(inputValue)
       const formattedJSON = JSON.stringify(parsedJSON, null, 2)
       const value = formattedJSON

--- a/frontend/src/components/Workspace/FlowChart/FlowChartNode/ExpDbNode.tsx
+++ b/frontend/src/components/Workspace/FlowChart/FlowChartNode/ExpDbNode.tsx
@@ -9,7 +9,7 @@ export const ExpDbNode = createExpDbNode(
   "ExpDbNode",
   {
     returnType: "ExpDbData",
-    handleName: "expdb",
+    handleName: "standard_expdb",
   },
   ExpDbSelectSingle,
 )

--- a/frontend/src/components/Workspace/FlowChart/TreeView.tsx
+++ b/frontend/src/components/Workspace/FlowChart/TreeView.tsx
@@ -132,14 +132,16 @@ export const AlgorithmTreeView = memo(function AlgorithmTreeView() {
 
       {/* Algorithm hierarchy remains static */}
       <TreeItem nodeId="Algorithm" label="Algorithm">
-        {Object.entries(algoList).map(([name, node], i) => (
-          <AlgoNodeComponentRecursive
-            name={name}
-            node={node}
-            onAddAlgoNode={onAddAlgoNode}
-            key={i.toFixed()}
-          />
-        ))}
+        {Object.entries(algoList)
+          .filter(([, node]) => node !== undefined)
+          .map(([name, node], i) => (
+            <AlgoNodeComponentRecursive
+              name={name}
+              node={node}
+              onAddAlgoNode={onAddAlgoNode}
+              key={i.toFixed()}
+            />
+          ))}
       </TreeItem>
     </TreeView>
   )
@@ -217,6 +219,11 @@ const AlgoNodeComponentRecursive = memo(function AlgoNodeComponentRecursive({
   node,
   onAddAlgoNode,
 }: AlgoNodeComponentRecursiveProps) {
+  // Guard against undefined nodes
+  if (!node) {
+    return null
+  }
+
   if (isAlgoChild(node)) {
     return (
       <AlgoNodeComponent
@@ -228,14 +235,16 @@ const AlgoNodeComponentRecursive = memo(function AlgoNodeComponentRecursive({
   } else {
     return (
       <TreeItem nodeId={name} label={name}>
-        {Object.entries(node.children).map(([name, node], i) => (
-          <AlgoNodeComponentRecursive
-            name={name}
-            node={node}
-            onAddAlgoNode={onAddAlgoNode}
-            key={i.toFixed()}
-          />
-        ))}
+        {Object.entries(node.children)
+          .filter(([, childNode]) => childNode !== undefined)
+          .map(([childName, childNode], i) => (
+            <AlgoNodeComponentRecursive
+              name={childName}
+              node={childNode}
+              onAddAlgoNode={onAddAlgoNode}
+              key={i.toFixed()}
+            />
+          ))}
       </TreeItem>
     )
   }

--- a/frontend/src/config/fileTypes.config.ts
+++ b/frontend/src/config/fileTypes.config.ts
@@ -169,7 +169,7 @@ export const FILE_TYPE_CONFIGS: Record<string, FileTypeConfig> = {
     nodeType: REACT_FLOW_NODE_TYPE_KEY.MicroscopeExpdbFileNode,
   },
   EXPDB: {
-    key: "expdb",
+    key: "standard_expdb",
     displayName: "preprocessed_data",
     hasFilePath: true,
     filePathType: "single",

--- a/frontend/src/store/slice/InputNode/InputNodeSelectors.ts
+++ b/frontend/src/store/slice/InputNode/InputNodeSelectors.ts
@@ -65,7 +65,7 @@ const generateTypedSelectors = () => {
       matlab: isMatlabInputNode,
       microscope: isMicroscopeInputNode,
       microscope_expdb: isMicroscopeExpDbInputNode,
-      expdb: isExpDbInputNode,
+      standard_expdb: isExpDbInputNode,
       expdb_batch_microscope_expdb: isExpdbBatchMicroscopeExpDbInputNode,
     }
 

--- a/frontend/src/store/slice/InputNode/InputNodeSlice.ts
+++ b/frontend/src/store/slice/InputNode/InputNodeSlice.ts
@@ -27,6 +27,7 @@ import {
   isCsvInputNode,
   isHDF5InputNode,
   isMatlabInputNode,
+  normalizeFileType,
 } from "store/slice/InputNode/InputNodeUtils"
 import {
   reproduceWorkflow,
@@ -208,12 +209,13 @@ export const inputNodeSlice = createSlice({
           .forEach((node) => {
             if (node.data?.fileType != null) {
               try {
-                const baseNode = FileNodeFactory.createInputNode(
-                  node.data.fileType,
-                )
+                // Backward compatibility: normalize deprecated file types
+                const fileType = normalizeFileType(node.data.fileType)
+
+                const baseNode = FileNodeFactory.createInputNode(fileType)
                 // Use specific param for CSV nodes
                 const param =
-                  node.data.fileType === FILE_TYPE_SET.CSV
+                  fileType === FILE_TYPE_SET.CSV
                     ? (node.data.param as CsvInputParamType)
                     : baseNode.param
                 newState[node.id] = {
@@ -241,19 +243,17 @@ export const inputNodeSlice = createSlice({
             .forEach((node) => {
               if (node.data?.fileType != null) {
                 try {
-                  const baseNode = FileNodeFactory.createInputNode(
-                    node.data.fileType,
-                  )
-                  const filePathType = FileNodeFactory.getFilePathType(
-                    node.data.fileType,
-                  )
-                  const specialPath = FileNodeFactory.getSpecialPathConfig(
-                    node.data.fileType,
-                  )
+                  // Backward compatibility: normalize deprecated file types
+                  const fileType = normalizeFileType(node.data.fileType)
+
+                  const baseNode = FileNodeFactory.createInputNode(fileType)
+                  const filePathType = FileNodeFactory.getFilePathType(fileType)
+                  const specialPath =
+                    FileNodeFactory.getSpecialPathConfig(fileType)
 
                   // Use specific param for CSV nodes
                   const param =
-                    node.data.fileType === FILE_TYPE_SET.CSV
+                    fileType === FILE_TYPE_SET.CSV
                       ? (node.data.param as CsvInputParamType)
                       : baseNode.param
 

--- a/frontend/src/store/slice/InputNode/InputNodeType.ts
+++ b/frontend/src/store/slice/InputNode/InputNodeType.ts
@@ -72,7 +72,7 @@ export interface MicroscopeExpdbInputNode
 }
 
 export interface ExpDbInputNode
-  extends InputNodeBaseType<"expdb", Record<never, never>> {
+  extends InputNodeBaseType<"standard_expdb", Record<never, never>> {
   selectedFilePath?: string
 }
 

--- a/frontend/src/store/slice/InputNode/InputNodeUtils.ts
+++ b/frontend/src/store/slice/InputNode/InputNodeUtils.ts
@@ -5,11 +5,30 @@ import {
   ExpDbInputNode,
   InputNodeType,
   FILE_TYPE_SET,
+  FILE_TYPE,
   MatlabInputNode,
   MicroscopeInputNode,
   MicroscopeExpdbInputNode,
   ExpdbBatchMicroscopeExpdbInputNode,
 } from "store/slice/InputNode/InputNodeType"
+
+/**
+ * File type migration mapping for backward compatibility
+ * Maps deprecated file type keys to their current equivalents
+ */
+const FILE_TYPE_MIGRATION_MAP: Record<string, FILE_TYPE> = {
+  expdb: FILE_TYPE_SET.EXPDB, // "expdb" -> "standard_expdb"
+}
+
+/**
+ * Normalize file type for backward compatibility
+ * Converts deprecated file type keys to their current equivalents
+ * @param fileType - The file type (possibly deprecated)
+ * @returns The normalized file type
+ */
+export function normalizeFileType(fileType: string): string {
+  return FILE_TYPE_MIGRATION_MAP[fileType] || fileType
+}
 
 export function isImageInputNode(
   inputNode: InputNodeType,


### PR DESCRIPTION
### Content

- Adjusted conflicting IDs between node IDs and logo IDs. 
   - Improved code clarity and fixed an issue where the node list in the left side menu could be unstable.
  - Specific explanation
  In some cases, the "expdb" folder in the Algo node could not be expanded (although it could sometimes be expanded).
- Implemented validation enhancements in the frontend where a `Cannot read properties of undefined` error could occur.
  - When this error occurs, the screen will be blank.

### Testcase

- [x] Opening and closing `Nodes > Algorithm > expb` in the left side menu no longer causes unstable conditions.
- [x] Reproducing a workflow containing a `preprocessed_data` node from the past (prior to this fix) no longer causes errors.
- [x] Navigating back and forth between the Experiments <-> Cells page in Open Site no longer causes the frontend to go blank.
