### PR TITLE
Fixed some minor issues

### DIFF
--- a/frontend/src/components/Workspace/__tests__/FlowChart/TreeView.test.tsx
+++ b/frontend/src/components/Workspace/__tests__/FlowChart/TreeView.test.tsx
@@ -26,8 +26,7 @@ jest.mock("react-dnd", () => ({
 
 const mockStore = configureStore([thunk])
 
-// TODO: temporary comment out for optinist-for-server
-describe.skip("AlgorithmTreeView", () => {
+describe("AlgorithmTreeView", () => {
   let store: ReturnType<typeof mockStore>
 
   beforeEach(() => {
@@ -65,6 +64,7 @@ describe.skip("AlgorithmTreeView", () => {
     expect(screen.getByText("matlab")).toBeInTheDocument()
     expect(screen.getByText("microscope")).toBeInTheDocument()
     expect(screen.getByText("microscope_database")).toBeInTheDocument()
+    expect(screen.getByText("preprocessed_data")).toBeInTheDocument()
   })
 
   it("renders the AlgorithmTree Algorithm TreeItems", async () => {

--- a/studio/app/optinist/routers/expdb.py
+++ b/studio/app/optinist/routers/expdb.py
@@ -390,9 +390,17 @@ async def get_config_filter_params(
 ):
     try:
         config = db.query(optinist_model.Config).one_or_none()
-        return parse_obj_as(
-            ExpDbExperimentFilterParams, config.experiment_config["filter_params"]
+        filter_params = (
+            parse_obj_as(
+                ExpDbExperimentFilterParams, config.experiment_config["filter_params"]
+            )
+            if config.experiment_config
+            else ExpDbExperimentFilterParams(
+                brain_areas=[], promoters=[], indicators=[], imaging_depths=[]
+            )
         )
+
+        return filter_params
     except sqlalchemy.exc.MultipleResultsFound as e:
         raise HTTPException(status_code=500, detail=str(e))
 


### PR DESCRIPTION
### Content

Fixed some minor issues

- #356
  - Addressed at 42dd326
    - An error occurred in a part where there was a difference in specifications with barebone-studio.
    - This may have been resolved by subsequent refactoring of the frontend.

- #438
  - Addressed at df06a80
    - This error does not occur during production: data is automatically generated when analysis batches are executed.
    - However, depending on the data registration status, an unnecessary error (unnecessary during development) was occurring, so this was addressed by adding validation.

### Testcase

- [x] #356
  -  No errors in `yarn test`
- [x] #438
  - [x] 1. If the database's config.experiment_config is null,
    - there should be no warnings in the backend.
    - Also, there should be no UI issues with the frontend datagrid filter.
    (The filter selection items (brain_areas, promoters, indicators, imaging_depths) should be empty.)
  - [x] 2. If the database's config.experiment_config is not null,
    - the frontend datagrid filter should function properly.
    (The filter selection items (brain_areas, promoters, indicators, imaging_depths) should be displayed.)
