### PR TITLE
Minor adjustments and bug fixes in the frontend

### DIFF
--- a/frontend/src/components/Database/DatabaseCells.tsx
+++ b/frontend/src/components/Database/DatabaseCells.tsx
@@ -1,6 +1,5 @@
 import { ChangeEvent, useCallback, useEffect, useMemo, useState } from "react"
 import { useDispatch, useSelector } from "react-redux"
-import { useSearchParams } from "react-router-dom"
 
 import CheckCircleIcon from "@mui/icons-material/CheckCircle"
 import { Box, Input, styled, Tooltip } from "@mui/material"
@@ -34,6 +33,7 @@ import {
   ImageUrls,
 } from "store/slice/Database/DatabaseType"
 import { AppDispatch, RootState } from "store/store"
+import { useUrlParamsSync } from "utils/useUrlParamsSync"
 
 type CellProps = {
   user?: unknown
@@ -472,9 +472,9 @@ const DatabaseCells = ({ user }: CellProps) => {
     filterParams: state[DATABASE_SLICE_NAME].filterParams,
   }))
 
-  const [newParams, setNewParams] = useState(
-    window.location.search.replace("?", ""),
-  )
+  const { searchParams, setNewParams } = useUrlParamsSync()
+  const dispatch = useDispatch<AppDispatch>()
+
   const [dataDialog, setDataDialog] = useState<{
     type: string
     data?: string | string[]
@@ -487,9 +487,6 @@ const DatabaseCells = ({ user }: CellProps) => {
   })
   const [fieldFilter, setFieldFilter] = useState("")
   const [valueFilter, setValueFilter] = useState<string | string[]>("")
-
-  const [searchParams, setParams] = useSearchParams()
-  const dispatch = useDispatch<AppDispatch>()
 
   const id = searchParams.get("id")
   const offset = searchParams.get("offset")
@@ -622,21 +619,6 @@ const DatabaseCells = ({ user }: CellProps) => {
     })
     //eslint-disable-next-line
   }, [dataParams, dataParamsFilter, fieldFilter, valueFilter])
-
-  useEffect(() => {
-    let param = newParams
-    if (newParams[0] === "&") param = newParams.slice(1, param.length)
-    if (param === window.location.search.replace("?", "")) return
-    setParams(param.replaceAll("+", "%2B"))
-    //eslint-disable-next-line
-  }, [newParams])
-
-  useEffect(() => {
-    if (newParams && newParams !== window.location.search.replace("?", "")) {
-      setNewParams(window.location.search.replace("?", ""))
-    }
-    //eslint-disable-next-line
-  }, [searchParams])
 
   useEffect(() => {
     dispatch(getOptionsFilter())

--- a/frontend/src/components/Database/DatabaseExperiments.tsx
+++ b/frontend/src/components/Database/DatabaseExperiments.tsx
@@ -7,7 +7,7 @@ import {
   useState,
 } from "react"
 import { shallowEqual, useDispatch, useSelector } from "react-redux"
-import { useNavigate, useSearchParams } from "react-router-dom"
+import { useNavigate } from "react-router-dom"
 
 import moment from "moment"
 import { enqueueSnackbar, VariantType } from "notistack"
@@ -76,6 +76,7 @@ import {
 } from "store/slice/Database/DatabaseType"
 import { isAdminOrManager } from "store/slice/User/UserSelector"
 import { AppDispatch, RootState } from "store/store"
+import { useUrlParamsSync } from "utils/useUrlParamsSync"
 
 export type Data = {
   id: number
@@ -643,9 +644,10 @@ const DatabaseExperiments = ({
     open: false,
     type: "on",
   })
-  const [newParams, setNewParams] = useState(
-    window.location.search.replace("?", ""),
-  )
+  const { searchParams, setNewParams } = useUrlParamsSync()
+  const dispatch = useDispatch<AppDispatch>()
+  const navigate = useNavigate()
+
   const [openShare, setOpenShare] = useState<{ open: boolean; id?: number }>({
     open: false,
   })
@@ -665,10 +667,6 @@ const DatabaseExperiments = ({
   })
   const [fieldFilter, setFieldFilter] = useState("")
   const [valueFilter, setValueFilter] = useState<string | string[]>("")
-
-  const [searchParams, setParams] = useSearchParams()
-  const dispatch = useDispatch<AppDispatch>()
-  const navigate = useNavigate()
 
   const offset = searchParams.get("offset") || 0
   const limit = searchParams.get("limit") || 50
@@ -829,21 +827,6 @@ const DatabaseExperiments = ({
     const isCheck = newListId.every((id) => listCheck.includes(id))
     setCheckBoxAll(isCheck)
   }, [dataExperiments, listCheck])
-
-  useEffect(() => {
-    if (newParams && newParams !== window.location.search.replace("?", "")) {
-      setNewParams(window.location.search.replace("?", ""))
-    }
-    //eslint-disable-next-line
-  }, [searchParams])
-
-  useEffect(() => {
-    let param = newParams
-    if (newParams[0] === "&") param = newParams.slice(1, param.length)
-    if (param === window.location.search.replace("?", "")) return
-    setParams(param.replaceAll("+", "%2B"))
-    //eslint-disable-next-line
-  }, [newParams])
 
   useEffect(() => {
     fetchApi()

--- a/frontend/src/components/Database/DatabaseExperiments.tsx
+++ b/frontend/src/components/Database/DatabaseExperiments.tsx
@@ -1173,6 +1173,22 @@ const DatabaseExperiments = ({
   const ColumnPrivate = () => {
     return [
       {
+        field: "updated_time",
+        headerName: "Timestamp",
+        width: 160,
+        filterable: false,
+        sortable: false,
+        renderCell: (params: { row: DatabaseType }) => {
+          return (
+            <Tooltip title={params.row?.updated_at}>
+              <SpanCustom>
+                {moment(params.row?.updated_at).format("YYYY/MM/DD HH:mm")}
+              </SpanCustom>
+            </Tooltip>
+          )
+        },
+      },
+      {
         field: "share_type",
         headerName: "Share",
         width: 120,
@@ -1251,24 +1267,6 @@ const DatabaseExperiments = ({
       columnsTable = columnsTable.slice(0, firstImageColumnIndex)
     }
   }
-
-  // Add timestamp column at the end (before ColumnPrivate)
-  columnsTable.push({
-    field: "updated_time",
-    headerName: "Timestamp",
-    width: 160,
-    filterable: false,
-    sortable: false,
-    renderCell: (params: { row: DatabaseType }) => {
-      return (
-        <Tooltip title={params.row?.updated_at}>
-          <SpanCustom>
-            {moment(params.row?.updated_at).format("YYYY/MM/DD HH:mm")}
-          </SpanCustom>
-        </Tooltip>
-      )
-    },
-  })
 
   /**
    * Preserve scroll position when row selection changes in multi-select mode

--- a/frontend/src/utils/useUrlParamsSync.ts
+++ b/frontend/src/utils/useUrlParamsSync.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef, useState } from "react"
+import { useSearchParams } from "react-router-dom"
+
+/**
+ * URLパラメーターの同期を管理するカスタムフック
+ *
+ * デフォルトパラメーター（limit, offset）の追加時は履歴を置き換え、
+ * ユーザー操作時は履歴に追加することで、ブラウザの戻る/進むボタンを正常に動作させる
+ */
+export const useUrlParamsSync = () => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [newParams, setNewParams] = useState(
+    window.location.search.replace("?", ""),
+  )
+
+  const isInitialMountRef = useRef(true)
+  const hasAddedDefaultParamsRef = useRef(false)
+
+  useEffect(() => {
+    if (isInitialMountRef.current) {
+      isInitialMountRef.current = false
+      return
+    }
+
+    let param = newParams
+    if (newParams[0] === "&") {
+      param = newParams.slice(1, param.length)
+    }
+
+    if (param === window.location.search.replace("?", "")) {
+      return
+    }
+
+    // デフォルトパラメーター（limit, offset）の追加を検出
+    const currentSearch = window.location.search.replace("?", "")
+    const isAddingDefaultParams =
+      !hasAddedDefaultParamsRef.current &&
+      currentSearch.length > 0 &&
+      param.length > currentSearch.length &&
+      param.includes("limit=") &&
+      param.includes("offset=")
+
+    if (isAddingDefaultParams) {
+      hasAddedDefaultParamsRef.current = true
+      setSearchParams(param.replaceAll("+", "%2B"), { replace: true })
+    } else {
+      setSearchParams(param.replaceAll("+", "%2B"))
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [newParams])
+
+  return {
+    searchParams,
+    setNewParams,
+  }
+}


### PR DESCRIPTION
### Content

- Adjustment
  - Adjusting the column display of public database page (f6273f5)
    - Turned off the display of timestamps column on public database page (preserving the display specifications of previous versions) 

- Bug fix
  - Fixed browser history back issue on database page
    - Fixed a bug where browser history back did not work properly between DatabaseExperiments and DatabaseCells. (faf3a3c)

### Testcase

- [x] Fixed browser history back issue on database page
  - Check procedure
    1. Set any filter on the /experiments page. Then go to the /cells page.
    2. From the /cells page, use browser history back to return to the /experiments screen.
    3. You can return to the /experiments screen, and the filters you set in step 1 will be restored.
