### PR TITLE
Skip rejected ROI, so indexes match

### DIFF
--- a/studio/app/optinist/wrappers/suite2p/suite2p_preprocessing.py
+++ b/studio/app/optinist/wrappers/suite2p/suite2p_preprocessing.py
@@ -299,9 +299,6 @@ def suite2p_preprocessing(
             # Step 4: Create visualization ROIs
             arrays = []
             for i, s in enumerate(stat):
-                if not iscell[i]:  # Skip rejected ROIs
-                    continue
-
                 if roi_thr_bool:
                     # Apply energy threshold to ROI pixels (like CaImAn's get_roi)
                     lam = np.array(s["lam"])


### PR DESCRIPTION
### Content

Hot fix to avoid index mismatch error.

  - CaImAn (line 257): Explicitly vstacks cells + non-cells → im has all ROIs
  - Suite2p (after fix): Loops through all ROIs without filtering → im has all ROIs

Both methods ensure im has all ROIs