### PR TITLE
Change suite2p_preprocessing to  pixel_mask

### DIFF
--- a/studio/app/optinist/wrappers/suite2p/suite2p_preprocessing.py
+++ b/studio/app/optinist/wrappers/suite2p/suite2p_preprocessing.py
@@ -460,18 +460,11 @@ def suite2p_preprocessing(
 
     nwbfile_out = {}
 
-    # Add ROI metadata (match caiman_preprocessing)
+    # Add ROI metadata (use pixel_mask in 512x512 space)
     roi_list = []
     for i, s in enumerate(stat):
-        roi_mask = ROI(
-            ypix=s["ypix"],
-            xpix=s["xpix"],
-            lam=s["lam"],
-            med=s["med"],
-            do_crop=False,
-        ).to_array(Ly=Ly, Lx=Lx)
         kargs = {
-            "image_mask": roi_mask,
+            "pixel_mask": np.array([s["ypix"], s["xpix"], s["lam"]]).T,
             "accepted": bool(iscell[i] == 1),
             "rejected": bool(iscell[i] == 0),
         }


### PR DESCRIPTION
### Content

Change suite2p_preprocessing to use the same method as suite2p/roi (`pixel_mask`). This will mean there is a different output from cnmf_preprocessing (`image_mask`), but it will align with optinist in general.`pixel_mask` is also much lighter in terms of data. 

### References

> *Links to reference information

### Testcase

#### Suite2p output plotting image_mask
<img width="790" height="796" alt="image_mask" src="https://github.com/user-attachments/assets/e704ec07-e7b5-4fe6-b4da-cc8398f2cb7a" />

#### Suite2p output plotting pixel_mask
<img width="671" height="601" alt="pixel_mask" src="https://github.com/user-attachments/assets/6d852985-831a-4e38-bfa2-8e2f5e2293f2" />

### It is acknowledged that the image_mask used the X by Y format, while pixel_mask uses Y by X. NWB specifies X, Y, and therefore caiman is correct. However, this is an issue in optinist and will not be addressed here.  

[plot_image_mask.py](https://github.com/user-attachments/files/24233095/plot_image_mask.py)
[plot_pixel_mask.py](https://github.com/user-attachments/files/24233096/plot_pixel_mask.py)


