### PR TITLE
Refactoring DatabaseExperiments column display conditions

### DIFF
--- a/frontend/src/components/Database/DatabaseExperiments.tsx
+++ b/frontend/src/components/Database/DatabaseExperiments.tsx
@@ -152,67 +152,17 @@ const LIST_FILTER_IS = [
 ]
 
 const columns = (
-  listIdData: number[],
-  setListCheck: (value: number[]) => void,
-  listCheck: number[],
-  dataExperiments: DatabaseType[],
-  checkBoxAll: boolean,
-  setCheckBoxAll: (value: boolean) => void,
   handleOpenAttributes: (value: string, id: number, expId?: string) => void,
   handleOpenLogs: (value: string, expId?: string) => void,
   handleOpenDialog: (value: ImageUrls[], exp_id?: string) => void,
   cellPath: string,
   navigate: (path: string) => void,
   user: boolean,
-  adminOrManager: boolean,
   readonly?: boolean,
   loading: boolean = false,
   options?: FilterParams,
   useExperimentsCatalogsApi: boolean = false,
 ) => [
-  adminOrManager &&
-    user &&
-    !readonly && {
-      field: "checkbox",
-      renderHeader: () => (
-        <Checkbox
-          checked={checkBoxAll}
-          onChange={(e: ChangeEvent) => {
-            const target = e.target as HTMLInputElement
-            setCheckBoxAll(target.checked)
-            if (!target.checked) {
-              const newListId: number[] = listCheck.filter(
-                (item) => !listIdData.includes(item),
-              )
-              setListCheck([...newListId])
-            } else {
-              const newList = dataExperiments.map((item) => item.id)
-              setListCheck([
-                ...listCheck,
-                ...newList.filter((item) => !listCheck.includes(item)),
-              ])
-            }
-          }}
-        />
-      ),
-      sortable: false,
-      filterable: false,
-      width: 70,
-      type: "string",
-      renderCell: (params: { row: DatabaseType }) => (
-        <Checkbox
-          checked={listCheck.includes(params.row.id)}
-          onChange={(e: ChangeEvent) => {
-            const newData = listCheck.filter((id) => id !== params.row.id)
-            const target = e.target as HTMLInputElement
-            if (!target.checked) {
-              setCheckBoxAll(false)
-              setListCheck(newData)
-            } else setListCheck([...listCheck, params.row.id])
-          }}
-        />
-      ),
-    },
   {
     field: "experiment_id",
     headerName: "Experiment ID",
@@ -1171,6 +1121,58 @@ const DatabaseExperiments = ({
           )
         },
       },
+    ]
+  }
+
+  const ColumnCheckbox = () => {
+    return [
+      {
+        field: "checkbox",
+        renderHeader: () => (
+          <Checkbox
+            checked={checkBoxAll}
+            onChange={(e: ChangeEvent) => {
+              const target = e.target as HTMLInputElement
+              setCheckBoxAll(target.checked)
+              if (!target.checked) {
+                const listIdData = dataExperiments.items.map((item) => item.id)
+                const newListId: number[] = listCheck.filter(
+                  (item) => !listIdData.includes(item),
+                )
+                setListCheck([...newListId])
+              } else {
+                const newList = dataExperiments.items.map((item) => item.id)
+                setListCheck([
+                  ...listCheck,
+                  ...newList.filter((item) => !listCheck.includes(item)),
+                ])
+              }
+            }}
+          />
+        ),
+        sortable: false,
+        filterable: false,
+        width: 70,
+        type: "string",
+        renderCell: (params: { row: DatabaseType }) => (
+          <Checkbox
+            checked={listCheck.includes(params.row.id)}
+            onChange={(e: ChangeEvent) => {
+              const newData = listCheck.filter((id) => id !== params.row.id)
+              const target = e.target as HTMLInputElement
+              if (!target.checked) {
+                setCheckBoxAll(false)
+                setListCheck(newData)
+              } else setListCheck([...listCheck, params.row.id])
+            }}
+          />
+        ),
+      },
+    ]
+  }
+
+  const ColumnManage = () => {
+    return [
       {
         field: "share_type",
         headerName: "Share",
@@ -1220,19 +1222,12 @@ const DatabaseExperiments = ({
 
   let columnsTable = [
     ...columns(
-      dataExperiments.items.map((item) => item.id),
-      setListCheck,
-      listCheck,
-      dataExperiments?.items,
-      checkBoxAll,
-      setCheckBoxAll,
       handleOpenAttributes,
       handleOpenLogs,
       handleOpenDialog,
       cellPath,
       navigate,
       !!user,
-      !!adminOrManager,
       readonly,
       loading,
       filterParams,
@@ -1392,9 +1387,12 @@ const DatabaseExperiments = ({
       >
         <DataGrid
           columns={
-            adminOrManager && user && !readonly
-              ? ([...columnsTable, ...ColumnPrivate()] as GridColDef[])
-              : (columnsTable as GridColDef[])
+            [
+              ...(user && adminOrManager && !readonly ? ColumnCheckbox() : []),
+              ...columnsTable,
+              ...(user ? ColumnPrivate() : []),
+              ...(user && adminOrManager && !readonly ? ColumnManage() : []),
+            ] as GridColDef[]
           }
           sortModel={model.sort as GridSortItem[]}
           rows={dataExperiments?.items || []}


### PR DESCRIPTION
### Content

In #496 f6273f5, I adjusted the DataGrid column display conditions, but the settings were not reflected in some components.
Also, since determining the display conditions was somewhat complicated, I applied a minor refactoring in addition to the above fixes.

#### Specification reorganization

- Separate the existing column group ColumnPrivate into ColumnManage and ColumnPrivate.
- `ColumnManage`
  - Included columns: checkbox, share_type, publish_status
  - Display condition: `user(==signed in) && adminOrManager && !readonly`
- `ColumnPrivate`
  - Included columns: updated_time
  - Display condition: `user(==signed in)`

### Testcase

**Note:**
Basically, there are no changes to the UI or behavior before and after the fix.
The following steps will verify that there are no changes (that the functionality is working properly).

#### Display confirmation

- [x] Called from frontend/src/pages/PublicDatabase/PublicExperiments.tsx
  - ColumnPrivate ... Off
  - ColumnManage ... Off
- [x] Called from frontend/src/pages/Database/Experiments.tsx
  - ColumnPrivate ... On
  - ColumnManage ... On
- [x] Called from frontend/src/components/Workspace/FlowChart/FlowChartNode/ExpDbSelectDialog.tsx
  - ColumnPrivate ... On
  - ColumnManage ... Off

#### DagaGrid operation

- [x] Open Site (PublicExperiments.tsx)
- [x] Console Database (Experiments.tsx)
- [x] Workflow nodes
  - [x] microscope_database (ExpDbSelectDialog.tsx)
  - [x] preprocessed_data (ExpDbSelectDialog.tsx)
  - [x] batch_database (ExpDbSelectDialog.tsx)

